### PR TITLE
Improve query string handling in Python output

### DIFF
--- a/fixtures/curl_commands/query_string_order_get.txt
+++ b/fixtures/curl_commands/query_string_order_get.txt
@@ -1,0 +1,1 @@
+curl 'http://localhost:8888/?firstparam=1&secondparam=2&firstparam=1'

--- a/fixtures/curl_commands/query_string_order_post.txt
+++ b/fixtures/curl_commands/query_string_order_post.txt
@@ -1,0 +1,1 @@
+curl -X POST 'http://localhost:8888/' --data 'firstparam=1&secondparam=2&firstparam=1'

--- a/fixtures/curl_commands/query_string_qmark.txt
+++ b/fixtures/curl_commands/query_string_qmark.txt
@@ -1,0 +1,1 @@
+curl 'http://localhost:8888/?'

--- a/fixtures/curl_commands/query_string_unparsable.txt
+++ b/fixtures/curl_commands/query_string_unparsable.txt
@@ -1,0 +1,1 @@
+curl 'http://localhost:8888/?noequalssign'

--- a/fixtures/python_output/query_string_order_get.py
+++ b/fixtures/python_output/query_string_order_get.py
@@ -1,0 +1,9 @@
+import requests
+
+params = [
+    ('firstparam', '1'),
+    ('secondparam', '2'),
+    ('firstparam', '1')
+]
+
+response = requests.get('http://localhost:8888/', params=params)

--- a/fixtures/python_output/query_string_order_post.py
+++ b/fixtures/python_output/query_string_order_post.py
@@ -1,0 +1,9 @@
+import requests
+
+data = [
+    ('firstparam', '1'),
+    ('secondparam', '2'),
+    ('firstparam', '1')
+]
+
+response = requests.post('http://localhost:8888/', data=data)

--- a/fixtures/python_output/query_string_qmark.py
+++ b/fixtures/python_output/query_string_qmark.py
@@ -1,0 +1,3 @@
+import requests
+
+response = requests.get('http://localhost:8888/?')

--- a/fixtures/python_output/query_string_unparsable.py
+++ b/fixtures/python_output/query_string_unparsable.py
@@ -1,0 +1,3 @@
+import requests
+
+response = requests.get('http://localhost:8888/?noequalssign')


### PR DESCRIPTION
The new tests in the PR should explain what I'm trying to accomplish here

- detect when a query string cannot be losslessly converted to a list of tuples/dict
- preserve ordering of arguments
- unify the code that parses query strings in --data and the URL

I still need to update the existing tests and clean up the code.