### PR TITLE
Readme edits

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ headers = {
 response = requests.get('http://en.wikipedia.org/', headers=headers, cookies=cookies)
 ```
 
+Note: for the above example to work as-is, it may be necessary to add `"type": "module"` to package.json.
+
 ## Contributing
 
 > I'd rather write programs to write programs than write programs.

--- a/README.md
+++ b/README.md
@@ -37,13 +37,12 @@ curlconverter requires Node 12+.
 
 ## Usage
 
-The JavaScript API is a bunch of functions that can take either a string of Bash code or an array
+The JavaScript API is a bunch of functions that can take a string of Bash code
 
 ```js
 import * as curlconverter from 'curlconverter';
 
 curlconverter.toPython("curl 'http://en.wikipedia.org/' -H 'Accept-Encoding: gzip, deflate, sdch' -H 'Accept-Language: en-US,en;q=0.8' -H 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.95 Safari/537.36' -H 'Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8' -H 'Referer: http://www.wikipedia.org/' -H 'Cookie: GeoIP=US:Albuquerque:35.1241:-106.7675:v4; uls-previous-languages=%5B%22en%22%5D; mediaWiki.user.sessionId=VaHaeVW3m0ymvx9kacwshZIDkv8zgF9y; centralnotice_buckets_by_campaign=%7B%22C14_enUS_dsk_lw_FR%22%3A%7B%22val%22%3A%220%22%2C%22start%22%3A1412172000%2C%22end%22%3A1422576000%7D%2C%22C14_en5C_dec_dsk_FR%22%3A%7B%22val%22%3A3%2C%22start%22%3A1417514400%2C%22end%22%3A1425290400%7D%2C%22C14_en5C_bkup_dsk_FR%22%3A%7B%22val%22%3A1%2C%22start%22%3A1417428000%2C%22end%22%3A1425290400%7D%7D; centralnotice_bannercount_fr12=22; centralnotice_bannercount_fr12-wait=14' -H 'Connection: keep-alive' --compressed");
-curlconverter.toPython(['curl', 'http://en.wikipedia.org/', '-H', 'Accept-Encoding: gzip, deflate, sdch', '-H', 'Accept-Language: en-US,en;q=0.8', '-H', 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.95 Safari/537.36', '-H', 'Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8', '-H', 'Referer: http://www.wikipedia.org/', '-H', 'Cookie: GeoIP=US:Albuquerque:35.1241:-106.7675:v4; uls-previous-languages=%5B%22en%22%5D; mediaWiki.user.sessionId=VaHaeVW3m0ymvx9kacwshZIDkv8zgF9y; centralnotice_buckets_by_campaign=%7B%22C14_enUS_dsk_lw_FR%22%3A%7B%22val%22%3A%220%22%2C%22start%22%3A1412172000%2C%22end%22%3A1422576000%7D%2C%22C14_en5C_dec_dsk_FR%22%3A%7B%22val%22%3A3%2C%22start%22%3A1417514400%2C%22end%22%3A1425290400%7D%2C%22C14_en5C_bkup_dsk_FR%22%3A%7B%22val%22%3A1%2C%22start%22%3A1417428000%2C%22end%22%3A1425290400%7D%7D; centralnotice_bannercount_fr12=22; centralnotice_bannercount_fr12-wait=14', '-H', 'Connection: keep-alive', '--compressed'])
 ```
 
 and return a string of code like:


### PR DESCRIPTION
Proposing we remove the array example for now in the README. It doesn't seem to work currently and I'm unclear why. Error included below.

Also added a tip for how to run the example as-is without import / module failure errors.

---

```
/Users/omitted/code/testtest/node_modules/curlconverter/util.js:16
  curlCommand = curlCommand.replace(/\\\r|\\\n/g, '')
                            ^

TypeError: curlCommand.replace is not a function
    at Object.parseCurlCommand (/Users/omitted/code/testtest/node_modules/curlconverter/util.js:16:29)
    at Module.toPython (/Users/omitted/code/testtest/node_modules/curlconverter/generators/python.js:199:24)
    at file:///Users/omitted/code/testtest/server.js:4:27
    at ModuleJob.run (node:internal/modules/esm/module_job:183:25)
    at async Loader.import (node:internal/modules/esm/loader:178:24)
    at async Object.loadESM (node:internal/process/esm_loader:68:5)
    at async handleMainPromise (node:internal/modules/run_main:63:12)
```