### PR TITLE
Depend on fork of yargs published on npm

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 const curlconverter = require('../index.js')
-const argv = require('yargs').argv
+const argv = require('@curlconverter/yargs').argv
 const fs = require('fs')
 
 // sets a default incase -l/--langauge isn't passed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,22 +1,21 @@
 {
   "name": "curlconverter",
-  "version": "3.20.0",
+  "version": "3.21.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "curlconverter",
-      "version": "3.20.0",
+      "version": "3.21.0",
       "license": "MIT",
       "dependencies": {
+        "@curlconverter/yargs": "^0.0.2",
         "cookie": "^0.4.1",
         "jsesc": "^3.0.2",
         "nunjucks": "^3.2.3",
         "query-string": "^7.0.1",
         "string.prototype.startswith": "^1.0.0",
-        "yamljs": "^0.3.0",
-        "yargs": "^17.2.1",
-        "yargs-parser": "git@github.com:curlconverter/yargs-parser.git"
+        "yamljs": "^0.3.0"
       },
       "bin": {
         "curlconverter": "bin/cli.js"
@@ -121,6 +120,31 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/@curlconverter/yargs": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@curlconverter/yargs/-/yargs-0.0.2.tgz",
+      "integrity": "sha512-Q1YEebpCY61kxme4wvU0/IN/uMBfG5pZOKCo9FU+w20ElPvN+eH2qEVbK1C12t3Tee3qeYLLEU6HkiUeO1gc4A==",
+      "dependencies": {
+        "@curlconverter/yargs-parser": "^0.0.1",
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@curlconverter/yargs-parser": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@curlconverter/yargs-parser/-/yargs-parser-0.0.1.tgz",
+      "integrity": "sha512-DbEVRYqrorzwqc63MQ3RODflut1tNla8ZCKo1h83lF7+fbntgubZsDfRDBv5Lxj3vkKuvAolysNM2ekwJev8wA==",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@eslint/eslintrc": {
@@ -3098,31 +3122,6 @@
         "json2yaml": "bin/json2yaml",
         "yaml2json": "bin/yaml2json"
       }
-    },
-    "node_modules/yargs": {
-      "version": "17.2.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.2.1.tgz",
-      "integrity": "sha512-XfR8du6ua4K6uLGm5S6fA+FIJom/MdJcFNVY8geLlp2v8GYbOXD4EB1tPNZsRn4vBzKGMgb5DRZMeWuFc2GO8Q==",
-      "dependencies": {
-        "cliui": "^7.0.2",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.0",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^20.2.2"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/yargs-parser": {
-      "version": "20.2.9",
-      "resolved": "git+ssh://git@github.com/curlconverter/yargs-parser.git#5da0dcc3b6964c705b9ac95c474f33400acde30a",
-      "license": "ISC",
-      "engines": {
-        "node": ">=10"
-      }
     }
   },
   "dependencies": {
@@ -3203,6 +3202,25 @@
           }
         }
       }
+    },
+    "@curlconverter/yargs": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@curlconverter/yargs/-/yargs-0.0.2.tgz",
+      "integrity": "sha512-Q1YEebpCY61kxme4wvU0/IN/uMBfG5pZOKCo9FU+w20ElPvN+eH2qEVbK1C12t3Tee3qeYLLEU6HkiUeO1gc4A==",
+      "requires": {
+        "@curlconverter/yargs-parser": "^0.0.1",
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5"
+      }
+    },
+    "@curlconverter/yargs-parser": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@curlconverter/yargs-parser/-/yargs-parser-0.0.1.tgz",
+      "integrity": "sha512-DbEVRYqrorzwqc63MQ3RODflut1tNla8ZCKo1h83lF7+fbntgubZsDfRDBv5Lxj3vkKuvAolysNM2ekwJev8wA=="
     },
     "@eslint/eslintrc": {
       "version": "0.3.0",
@@ -5395,24 +5413,6 @@
         "argparse": "^1.0.7",
         "glob": "^7.0.5"
       }
-    },
-    "yargs": {
-      "version": "17.2.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.2.1.tgz",
-      "integrity": "sha512-XfR8du6ua4K6uLGm5S6fA+FIJom/MdJcFNVY8geLlp2v8GYbOXD4EB1tPNZsRn4vBzKGMgb5DRZMeWuFc2GO8Q==",
-      "requires": {
-        "cliui": "^7.0.2",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.0",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^20.2.2"
-      }
-    },
-    "yargs-parser": {
-      "version": "git+ssh://git@github.com/curlconverter/yargs-parser.git#5da0dcc3b6964c705b9ac95c474f33400acde30a",
-      "from": "yargs-parser@git@github.com:curlconverter/yargs-parser.git"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "curlconverter",
-  "version": "3.20.0",
+  "version": "3.21.0",
   "description": "convert curl syntax to native python and javascript http code",
   "homepage": "https://github.com/NickCarneiro/curlconverter",
   "author": {
@@ -25,8 +25,7 @@
     "query-string": "^7.0.1",
     "string.prototype.startswith": "^1.0.0",
     "yamljs": "^0.3.0",
-    "yargs": "^17.2.1",
-    "yargs-parser": "git@github.com:curlconverter/yargs-parser.git"
+    "@curlconverter/yargs": "^0.0.2"
   },
   "devDependencies": {
     "standard": "^16.0.4",

--- a/test.js
+++ b/test.js
@@ -4,7 +4,7 @@ const fs = require('fs')
 
 const utils = require('./util')
 const curlconverter = require('./index.js')
-const yargs = require('yargs')
+const yargs = require('@curlconverter/yargs')
 
 // the curl_commands/ directory contains input files
 // The file name is a description of the command.

--- a/util.js
+++ b/util.js
@@ -1,5 +1,5 @@
 const cookie = require('cookie')
-const yargs = require('yargs')
+const yargs = require('@curlconverter/yargs')
 const URL = require('url')
 const querystring = require('query-string')
 const nunjucks = require('nunjucks')


### PR DESCRIPTION
so that users don't need to install and configure Git to `npm install curlconverter@3`

Closes #269
Closes #261
Closes #246