### PR TITLE
Parse headers to a list of lists

### DIFF
--- a/fixtures/java/get_with_header_without_value.java
+++ b/fixtures/java/get_with_header_without_value.java
@@ -12,6 +12,7 @@ class Main {
 		httpConn.setRequestMethod("GET");
 
 		httpConn.setRequestProperty("Content-Type", "text/xml;charset=UTF-8");
+		httpConn.setRequestProperty("getWorkOrderCancel", "");
 
 		InputStream responseStream = httpConn.getResponseCode() / 100 == 2
 				? httpConn.getInputStream()

--- a/fixtures/parser/get_with_browser_headers.json
+++ b/fixtures/parser/get_with_browser_headers.json
@@ -2,14 +2,32 @@
   "url": "http://en.wikipedia.org/",
   "urlWithoutQuery": "http://en.wikipedia.org/",
   "compressed": true,
-  "headers": {
-    "Accept-Encoding": "gzip, deflate, sdch",
-    "Accept-Language": "en-US,en;q=0.8",
-    "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.95 Safari/537.36",
-    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
-    "Referer": "http://www.wikipedia.org/",
-    "Connection": "keep-alive"
-  },
+  "headers": [
+    [
+      "Accept-Encoding",
+      "gzip, deflate, sdch"
+    ],
+    [
+      "Accept-Language",
+      "en-US,en;q=0.8"
+    ],
+    [
+      "User-Agent",
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.95 Safari/537.36"
+    ],
+    [
+      "Accept",
+      "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8"
+    ],
+    [
+      "Referer",
+      "http://www.wikipedia.org/"
+    ],
+    [
+      "Connection",
+      "keep-alive"
+    ]
+  ],
   "method": "get",
   "cookies": {
     "GeoIP": "US:Albuquerque:35.1241:-106.7675:v4",

--- a/fixtures/parser/get_with_browser_headers.json
+++ b/fixtures/parser/get_with_browser_headers.json
@@ -10,6 +10,7 @@
     "Referer": "http://www.wikipedia.org/",
     "Connection": "keep-alive"
   },
+  "method": "get",
   "cookies": {
     "GeoIP": "US:Albuquerque:35.1241:-106.7675:v4",
     "uls-previous-languages": "%5B%22en%22%5D",
@@ -18,6 +19,5 @@
     "centralnotice_bannercount_fr12": "22",
     "centralnotice_bannercount_fr12-wait": "14"
   },
-  "method": "get",
   "cookieString": "GeoIP=US:Albuquerque:35.1241:-106.7675:v4; uls-previous-languages=%5B%22en%22%5D; mediaWiki.user.sessionId=VaHaeVW3m0ymvx9kacwshZIDkv8zgF9y; centralnotice_buckets_by_campaign=%7B%22C14_enUS_dsk_lw_FR%22%3A%7B%22val%22%3A%220%22%2C%22start%22%3A1412172000%2C%22end%22%3A1422576000%7D%2C%22C14_en5C_dec_dsk_FR%22%3A%7B%22val%22%3A3%2C%22start%22%3A1417514400%2C%22end%22%3A1425290400%7D%2C%22C14_en5C_bkup_dsk_FR%22%3A%7B%22val%22%3A1%2C%22start%22%3A1417428000%2C%22end%22%3A1425290400%7D%7D; centralnotice_bannercount_fr12=22; centralnotice_bannercount_fr12-wait=14"
 }

--- a/fixtures/parser/multiline_post_with_data.json
+++ b/fixtures/parser/multiline_post_with_data.json
@@ -1,9 +1,12 @@
 {
   "url": "http://fiddle.jshell.net/echo/html/",
   "urlWithoutQuery": "http://fiddle.jshell.net/echo/html/",
-  "headers": {
-    "Origin": "http://fiddle.jshell.net"
-  },
+  "headers": [
+    [
+      "Origin",
+      "http://fiddle.jshell.net"
+    ]
+  ],
   "method": "get",
   "data": "msg1=value1&msg2=value2",
   "dataArray": [

--- a/fixtures/parser/post_with_browser_headers.json
+++ b/fixtures/parser/post_with_browser_headers.json
@@ -12,11 +12,11 @@
     "Connection": "keep-alive",
     "Content-Length": "0"
   },
+  "method": "post",
   "cookies": {
     "_gat": "1",
     "ASPSESSIONIDACCRDTDC": "MCMDKFMBLLLHGKCGNMKNGPKI",
     "_ga": "GA1.2.1424920226.1419478126"
   },
-  "method": "post",
   "cookieString": "_gat=1; ASPSESSIONIDACCRDTDC=MCMDKFMBLLLHGKCGNMKNGPKI; _ga=GA1.2.1424920226.1419478126"
 }

--- a/fixtures/parser/post_with_browser_headers.json
+++ b/fixtures/parser/post_with_browser_headers.json
@@ -2,16 +2,40 @@
   "url": "http://www.w3schools.com/ajax/demo_post.asp",
   "urlWithoutQuery": "http://www.w3schools.com/ajax/demo_post.asp",
   "compressed": true,
-  "headers": {
-    "Origin": "http://www.w3schools.com",
-    "Accept-Encoding": "gzip, deflate",
-    "Accept-Language": "en-US,en;q=0.8",
-    "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.95 Safari/537.36",
-    "Accept": "*/*",
-    "Referer": "http://www.w3schools.com/ajax/tryit_view.asp?x=0.07944501144811511",
-    "Connection": "keep-alive",
-    "Content-Length": "0"
-  },
+  "headers": [
+    [
+      "Origin",
+      "http://www.w3schools.com"
+    ],
+    [
+      "Accept-Encoding",
+      "gzip, deflate"
+    ],
+    [
+      "Accept-Language",
+      "en-US,en;q=0.8"
+    ],
+    [
+      "User-Agent",
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.95 Safari/537.36"
+    ],
+    [
+      "Accept",
+      "*/*"
+    ],
+    [
+      "Referer",
+      "http://www.w3schools.com/ajax/tryit_view.asp?x=0.07944501144811511"
+    ],
+    [
+      "Connection",
+      "keep-alive"
+    ],
+    [
+      "Content-Length",
+      "0"
+    ]
+  ],
   "method": "post",
   "cookies": {
     "_gat": "1",

--- a/fixtures/parser/post_with_urlencoded_data.json
+++ b/fixtures/parser/post_with_urlencoded_data.json
@@ -2,17 +2,44 @@
   "url": "http://fiddle.jshell.net/echo/html/",
   "urlWithoutQuery": "http://fiddle.jshell.net/echo/html/",
   "compressed": true,
-  "headers": {
-    "Origin": "http://fiddle.jshell.net",
-    "Accept-Encoding": "gzip, deflate",
-    "Accept-Language": "en-US,en;q=0.8",
-    "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.95 Safari/537.36",
-    "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8",
-    "Accept": "*/*",
-    "Referer": "http://fiddle.jshell.net/_display/",
-    "X-Requested-With": "XMLHttpRequest",
-    "Connection": "keep-alive"
-  },
+  "headers": [
+    [
+      "Origin",
+      "http://fiddle.jshell.net"
+    ],
+    [
+      "Accept-Encoding",
+      "gzip, deflate"
+    ],
+    [
+      "Accept-Language",
+      "en-US,en;q=0.8"
+    ],
+    [
+      "User-Agent",
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.95 Safari/537.36"
+    ],
+    [
+      "Content-Type",
+      "application/x-www-form-urlencoded; charset=UTF-8"
+    ],
+    [
+      "Accept",
+      "*/*"
+    ],
+    [
+      "Referer",
+      "http://fiddle.jshell.net/_display/"
+    ],
+    [
+      "X-Requested-With",
+      "XMLHttpRequest"
+    ],
+    [
+      "Connection",
+      "keep-alive"
+    ]
+  ],
   "method": "post",
   "data": "msg1=wow&msg2=such"
 }

--- a/fixtures/python/delete_content_type.py
+++ b/fixtures/python/delete_content_type.py
@@ -1,5 +1,9 @@
 import requests
 
+headers = {
+    # 'Content-Type': 'application/json',
+}
+
 json_data = {}
 
-response = requests.post('http://example.com', json=json_data)
+response = requests.post('http://example.com', headers=headers, json=json_data)

--- a/fixtures/python/delete_content_type.py
+++ b/fixtures/python/delete_content_type.py
@@ -1,6 +1,7 @@
 import requests
 
 headers = {
+    # Already added when you pass json=
     # 'Content-Type': 'application/json',
 }
 

--- a/fixtures/python/get_with_header_without_value.py
+++ b/fixtures/python/get_with_header_without_value.py
@@ -2,6 +2,7 @@ import requests
 
 headers = {
     'Content-Type': 'text/xml;charset=UTF-8',
+    'getWorkOrderCancel': '',
 }
 
 response = requests.get('http://postman-echo.com/get', headers=headers)

--- a/fixtures/python/patch.py
+++ b/fixtures/python/patch.py
@@ -2,7 +2,8 @@ import requests
 
 headers = {
     'Accept': 'application/vnd.go.cd.v4+json',
-    'Content-Type': 'application/json',
+    # Already added when you pass json= but not when you pass data=
+    # 'Content-Type': 'application/json',
 }
 
 json_data = {

--- a/fixtures/python/patch.py
+++ b/fixtures/python/patch.py
@@ -20,8 +20,7 @@ json_data = {
 
 response = requests.patch('https://ci.example.com/go/api/agents/adb9540a-b954-4571-9d9b-2f330739d4da', headers=headers, json=json_data, auth=('username', 'password'))
 
-# Note: the data is posted as JSON, which might not be serialized
-# by Requests exactly as it appears in the original command. So
-# the original data is also given.
+# Note: json_data will not be serialized by requests
+# exactly as it was in the original request.
 #data = '{\n        "hostname": "agent02.example.com",\n        "agent_config_state": "Enabled",\n        "resources": ["Java","Linux"],\n        "environments": ["Dev"]\n        }'
 #response = requests.patch('https://ci.example.com/go/api/agents/adb9540a-b954-4571-9d9b-2f330739d4da', headers=headers, data=data, auth=('username', 'password'))

--- a/fixtures/python/post_json_multiple_headers.py
+++ b/fixtures/python/post_json_multiple_headers.py
@@ -14,8 +14,7 @@ json_data = {
 
 response = requests.post('https://0.0.0.0/rest/login-sessions', headers=headers, json=json_data, verify=False)
 
-# Note: the data is posted as JSON, which might not be serialized
-# by Requests exactly as it appears in the original command. So
-# the original data is also given.
+# Note: json_data will not be serialized by requests
+# exactly as it was in the original request.
 #data = '{"userName":"username123","password":"password123", "authLoginDomain":"local"}'
 #response = requests.post('https://0.0.0.0/rest/login-sessions', headers=headers, data=data, verify=False)

--- a/fixtures/python/post_json_multiple_headers.py
+++ b/fixtures/python/post_json_multiple_headers.py
@@ -1,7 +1,8 @@
 import requests
 
 headers = {
-    'Content-Type': 'application/json',
+    # Already added when you pass json= but not when you pass data=
+    # 'Content-Type': 'application/json',
     'X-API-Version': '200',
 }
 

--- a/fixtures/python/post_with_extra_whitespace.py
+++ b/fixtures/python/post_with_extra_whitespace.py
@@ -2,6 +2,7 @@ import requests
 
 headers = {
     'accept': 'application/json',
+    # requests won't add a boundary if this header is set
     # 'Content-Type': 'multipart/form-data',
 }
 

--- a/fixtures/python/post_with_extra_whitespace.py
+++ b/fixtures/python/post_with_extra_whitespace.py
@@ -2,7 +2,6 @@ import requests
 
 headers = {
     'accept': 'application/json',
-    'Content-Type': 'multipart/form-data',
 }
 
 files = {

--- a/fixtures/python/post_with_extra_whitespace.py
+++ b/fixtures/python/post_with_extra_whitespace.py
@@ -2,7 +2,7 @@ import requests
 
 headers = {
     'accept': 'application/json',
-    # requests won't add a boundary if this header is set
+    # requests won't add a boundary if this header is set when you pass files=
     # 'Content-Type': 'multipart/form-data',
 }
 

--- a/fixtures/python/post_with_extra_whitespace.py
+++ b/fixtures/python/post_with_extra_whitespace.py
@@ -2,6 +2,7 @@ import requests
 
 headers = {
     'accept': 'application/json',
+    # 'Content-Type': 'multipart/form-data',
 }
 
 files = {

--- a/fixtures/python/put_with_T_option.py
+++ b/fixtures/python/put_with_T_option.py
@@ -15,8 +15,7 @@ json_data = {
 
 response = requests.put('http://localhost:9200/twitter/_mapping/user?pretty', headers=headers, json=json_data)
 
-# Note: the data is posted as JSON, which might not be serialized
-# by Requests exactly as it appears in the original command. So
-# the original data is also given.
+# Note: json_data will not be serialized by requests
+# exactly as it was in the original request.
 #data = '{"properties": {"email": {"type": "keyword"}}}'
 #response = requests.put('http://localhost:9200/twitter/_mapping/user?pretty', headers=headers, data=data)

--- a/fixtures/python/put_with_T_option.py
+++ b/fixtures/python/put_with_T_option.py
@@ -1,7 +1,8 @@
 import requests
 
 headers = {
-    'Content-Type': 'application/json',
+    # Already added when you pass json= but not when you pass data=
+    # 'Content-Type': 'application/json',
 }
 
 json_data = {

--- a/fixtures/python/put_xput.py
+++ b/fixtures/python/put_xput.py
@@ -15,8 +15,7 @@ json_data = {
 
 response = requests.put('http://localhost:9200/twitter/_mapping/user?pretty', headers=headers, json=json_data)
 
-# Note: the data is posted as JSON, which might not be serialized
-# by Requests exactly as it appears in the original command. So
-# the original data is also given.
+# Note: json_data will not be serialized by requests
+# exactly as it was in the original request.
 #data = '{"properties": {"email": {"type": "keyword"}}}'
 #response = requests.put('http://localhost:9200/twitter/_mapping/user?pretty', headers=headers, data=data)

--- a/fixtures/python/put_xput.py
+++ b/fixtures/python/put_xput.py
@@ -1,7 +1,8 @@
 import requests
 
 headers = {
-    'Content-Type': 'application/json',
+    # Already added when you pass json= but not when you pass data=
+    # 'Content-Type': 'application/json',
 }
 
 json_data = {

--- a/generators/dart.js
+++ b/generators/dart.js
@@ -33,7 +33,9 @@ export const _toDart = r => {
   const hasHeaders = r.headers || r.cookies || r.compressed || r.isDataBinary || r.method === 'put'
   if (hasHeaders) {
     s += '  var headers = {\n'
-    for (const hname in r.headers) s += "    '" + hname + "': '" + r.headers[hname] + "',\n"
+    for (const [hname, hval] of (r.headers || [])) {
+      s += "    '" + hname + "': '" + hval + "',\n"
+    }
 
     if (r.cookies) {
       const cookiestr = util.serializeCookies(r.cookies)
@@ -42,7 +44,7 @@ export const _toDart = r => {
 
     if (r.auth) s += "    'Authorization': authn,\n"
     if (r.compressed) s += "    'Accept-Encoding': 'gzip',\n"
-    if (!hasHeaders['Content-Type'] && (r.isDataBinary || r.method === 'put')) {
+    if (!util.hasHeader(r, 'content-type') && (r.isDataBinary || r.method === 'put')) {
       s += "    'Content-Type': 'application/x-www-form-urlencoded',\n"
     }
 

--- a/generators/elixir.js
+++ b/generators/elixir.js
@@ -75,8 +75,8 @@ function getHeadersDict (request) {
     return '[]'
   }
   let dict = '[\n'
-  for (const headerName in request.headers) {
-    dict += `    {${repr(headerName)}, ${repr(request.headers[headerName])}},\n`
+  for (const [headerName, headerValue] of request.headers) {
+    dict += `    {${repr(headerName)}, ${repr(headerValue)}},\n`
   }
   dict += '  ]'
   return dict

--- a/generators/go.js
+++ b/generators/go.js
@@ -19,8 +19,8 @@ export const _toGo = request => {
   }
   goCode += '\tif err != nil {\n\t\tlog.Fatal(err)\n\t}\n'
   if (request.headers || request.cookies) {
-    for (const headerName in request.headers) {
-      goCode += '\treq.Header.Set("' + headerName + '", "' + request.headers[headerName] + '")\n'
+    for (const [headerName, headerValue] of (request.headers || [])) {
+      goCode += '\treq.Header.Set("' + headerName + '", "' + headerValue + '")\n'
     }
     if (request.cookies) {
       const cookieString = util.serializeCookies(request.cookies)

--- a/generators/java.js
+++ b/generators/java.js
@@ -30,10 +30,10 @@ export const _toJava = request => {
 
   let gzip = false
   if (request.headers) {
-    for (const headerName in request.headers) {
-      javaCode += '\t\thttpConn.setRequestProperty("' + headerName + '", "' + doubleQuotes(request.headers[headerName]) + '");\n'
+    for (const [headerName, headerValue] of request.headers) {
+      javaCode += '\t\thttpConn.setRequestProperty("' + headerName + '", "' + doubleQuotes(headerValue) + '");\n'
       if (headerName.toLowerCase() === 'accept-encoding') {
-        gzip = request.headers[headerName].indexOf('gzip') !== -1
+        gzip = headerValue.indexOf('gzip') !== -1
       }
     }
     javaCode += '\n'

--- a/generators/javascript/javascript.js
+++ b/generators/javascript/javascript.js
@@ -14,11 +14,11 @@ export const _toJavaScript = request => {
       JSON.parse(request.data)
 
       if (!request.headers) {
-        request.headers = {}
+        request.headers = []
       }
 
-      if (!request.headers['Content-Type']) {
-        request.headers['Content-Type'] = 'application/json; charset=UTF-8'
+      if (!util.hasHeader(request, 'Content-Type')) {
+        request.headers.push(['Content-Type', 'application/json; charset=UTF-8'])
       }
 
       request.data = 'JSON.stringify(' + request.data + ')'
@@ -41,10 +41,10 @@ export const _toJavaScript = request => {
         jsFetchCode += ',\n'
       }
       jsFetchCode += '    headers: {\n'
-      const headerCount = Object.keys(request.headers || {}).length
+      const headerCount = request.headers ? request.headers.length : 0
       let i = 0
-      for (const headerName in request.headers) {
-        jsFetchCode += '        \'' + headerName + '\': \'' + request.headers[headerName] + '\''
+      for (const [headerName, headerValue] of (request.headers || [])) {
+        jsFetchCode += '        \'' + headerName + '\': \'' + headerValue + '\''
         if (i < headerCount - 1 || request.cookies || request.auth) {
           jsFetchCode += ',\n'
         }

--- a/generators/javascript/node-request.js
+++ b/generators/javascript/node-request.js
@@ -5,10 +5,10 @@ export const _toNodeRequest = request => {
   let nodeRequestCode = 'var request = require(\'request\');\n\n'
   if (request.headers || request.cookies) {
     nodeRequestCode += 'var headers = {\n'
-    const headerCount = Object.keys(request.headers).length
+    const headerCount = request.headers ? request.headers.length : 0
     let i = 0
-    for (const headerName in request.headers) {
-      nodeRequestCode += '    \'' + headerName + '\': \'' + request.headers[headerName] + '\''
+    for (const [headerName, headerValue] of (request.headers || [])) {
+      nodeRequestCode += '    \'' + headerName + '\': \'' + headerValue + '\''
       if (i < headerCount - 1 || request.cookies) {
         nodeRequestCode += ',\n'
       } else {

--- a/generators/json.js
+++ b/generators/json.js
@@ -110,12 +110,8 @@ export const _toJsonString = request => {
   }
 
   if (request.headers) {
-    const headers = {}
-    for (const headerName in request.headers) {
-      headers[repr(headerName)] = repr(request.headers[headerName])
-    }
-
-    requestJson.headers = headers
+    // TODO: what if Object.keys().length !== request.headers.length?
+    requestJson.headers = Object.fromEntries(request.headers)
   }
 
   if (request.queryDict) {

--- a/generators/matlab/httpinterface.js
+++ b/generators/matlab/httpinterface.js
@@ -8,15 +8,13 @@ const prepareHeaders = (request) => {
   let response = null
 
   if (request.headers) {
-    const headerEntries = Object.entries(request.headers)
-
     // cookies are part of headers
-    const headerCount = headerEntries.length + (request.cookies ? 1 : 0)
+    const headerCount = request.headers.length + (request.cookies ? 1 : 0)
 
     const headers = []
     let header = headerCount === 1 ? '' : '['
 
-    for (const [key, value] of headerEntries) {
+    for (const [key, value] of request.headers) {
       switch (key) {
         case 'Cookie':
           break

--- a/generators/matlab/webservices.js
+++ b/generators/matlab/webservices.js
@@ -33,7 +33,7 @@ const parseWebOptions = (request) => {
   }
 
   if (request.headers) {
-    for (const [key, value] of Object.entries(request.headers)) {
+    for (const [key, value] of request.headers) {
       switch (key) {
         case 'User-Agent':
           options.UserAgent = value

--- a/generators/php/php-requests.js
+++ b/generators/php/php-requests.js
@@ -10,9 +10,9 @@ export const _toPhpRequests = request => {
   if (request.headers) {
     headerString = '$headers = array(\n'
     let i = 0
-    const headerCount = Object.keys(request.headers).length
-    for (const headerName in request.headers) {
-      headerString += "    '" + headerName + "' => '" + quote(request.headers[headerName]) + "'"
+    const headerCount = request.headers ? request.headers.length : 0
+    for (const [headerName, headerValue] of request.headers) {
+      headerString += "    '" + headerName + "' => '" + quote(headerValue) + "'"
       if (i < headerCount - 1) {
         headerString += ',\n'
       }

--- a/generators/php/php.js
+++ b/generators/php/php.js
@@ -14,22 +14,17 @@ export const _toPhp = request => {
     let headersArrayCode = '[\n'
 
     if (request.compressed) {
-      if (typeof request.headers === 'object') {
-        let isAcceptEncodingSet = false
-        for (const headerName in request.headers) {
-          if (headerName.toLowerCase() === 'accept-encoding') {
-            isAcceptEncodingSet = true
-            break
-          }
+      if (request.headers) {
+        if (!util.hasHeader(request, 'accept-encoding')) {
+          request.headers.push(['Accept-Encoding', 'gzip'])
         }
-        if (!isAcceptEncodingSet) { request.headers['Accept-Encoding'] = 'gzip' }
       } else {
         headersArrayCode += "    'Accept-Encoding' => 'gzip',\n"
       }
     }
 
-    for (const headerName in request.headers) {
-      headersArrayCode += "    '" + quote(headerName) + "' => '" + quote(request.headers[headerName]) + "',\n"
+    for (const [headerName, headerValue] of (request.headers || [])) {
+      headersArrayCode += "    '" + quote(headerName) + "' => '" + quote(headerValue) + "',\n"
     }
 
     headersArrayCode += ']'

--- a/generators/python.js
+++ b/generators/python.js
@@ -268,7 +268,7 @@ export const _toPython = request => {
     // https://github.com/curlconverter/curlconverter/issues/248
     if (filesString && util.getHeader(request, 'content-type') === 'multipart/form-data') {
       // TODO: better wording
-      commentedOutHeaders['content-type'] = "requests won't add a boundary if this header is set"
+      commentedOutHeaders['content-type'] = "requests won't add a boundary if this header is set when you pass files="
     }
   }
 
@@ -390,9 +390,8 @@ export const _toPython = request => {
 
   if (jsonDataString && !jsonDataStringRoundtrips) {
     pythonCode += '\n\n' +
-            '# Note: the data is posted as JSON, which might not be serialized\n' +
-            '# by Requests exactly as it appears in the original command. So\n' +
-            '# the original data is also given.\n'
+            '# Note: json_data will not be serialized by requests\n' +
+            '# exactly as it was in the original request.\n'
     pythonCode += '#' + dataString
     pythonCode += '#' + requestLine.replace(', json=json_data', ', data=data')
   }

--- a/generators/python.js
+++ b/generators/python.js
@@ -234,6 +234,7 @@ const deleteHeader = (request, header) => {
   for (const existingHeader of Object.keys(request.headers)) {
     if (existingHeader.toLowerCase() === header) {
       delete request.headers[existingHeader]
+      // TODO: warn users about deleted header
     }
   }
 
@@ -296,7 +297,6 @@ export const _toPython = request => {
     if (filesString && getHeader(request, 'content-type') === 'multipart/form-data') {
       deleteHeader(request, 'content-type')
     }
-
   }
 
   let headerDict

--- a/generators/r.js
+++ b/generators/r.js
@@ -123,8 +123,8 @@ export const _toR = request => {
   if (request.headers) {
     const hels = []
     headerDict = 'headers = c(\n'
-    for (const headerName in request.headers) {
-      hels.push('  ' + reprn(headerName) + ' = ' + repr(request.headers[headerName]))
+    for (const [headerName, headerValue] of request.headers) {
+      hels.push('  ' + reprn(headerName) + ' = ' + repr(headerValue))
     }
     headerDict += hels.join(',\n')
     headerDict += '\n)\n'

--- a/generators/rust.js
+++ b/generators/rust.js
@@ -26,9 +26,8 @@ export const _toRust = request => {
 
   if (request.headers || request.cookies) {
     lines.push(indent('let mut headers = header::HeaderMap::new();'))
-    for (const headerName in request.headers) {
-      const headerValue = quote(request.headers[headerName])
-      lines.push(indent(`headers.insert("${headerName}", "${headerValue}".parse().unwrap());`))
+    for (const [headerName, headerValue] of (request.headers || [])) {
+      lines.push(indent(`headers.insert("${headerName}", "${quote(headerValue)}".parse().unwrap());`))
     }
 
     if (request.cookies) {

--- a/generators/strest.js
+++ b/generators/strest.js
@@ -23,9 +23,9 @@ function getDataString (request) {
     } catch (e) {}
   }
 
-  for (const paramName in request.headers) {
+  for (const [paramName, paramValue] of (request.headers || [])) {
     if (paramName === 'Content-Type') {
-      mimeType = request.headers[paramName]
+      mimeType = paramValue
     }
   }
   return {
@@ -61,10 +61,10 @@ export const _toStrest = request => {
 
   if (request.headers) {
     response.requests.curl_converter.request.headers = []
-    for (const prop in request.headers) {
+    for (const [name, value] of request.headers) {
       response.requests.curl_converter.request.headers.push({
-        name: prop,
-        value: request.headers[prop]
+        name,
+        value
       })
     }
     if (request.cookieString) {

--- a/tools/gen-test.js
+++ b/tools/gen-test.js
@@ -86,8 +86,7 @@ for (const inPath of inPaths) {
 }
 if (!printEachFile) {
   console.error('wrote', total, 'file' + (total === 1 ? '' : 's'))
-} 
-
+}
 
 if (inPaths.length && languages.length) {
   console.error('Please carefully check all the output for correctness before committing.')

--- a/tools/gen-test.js
+++ b/tools/gen-test.js
@@ -53,6 +53,8 @@ const inPaths = argv._.map((infile) => {
   return fullPath
 })
 
+const printEachFile = inPaths.length < 10 || languages.length < Object.keys(converters).length
+let total = 0
 for (const inPath of inPaths) {
   const curl = fs.readFileSync(inPath, 'utf8')
   for (const language of languages) {
@@ -75,9 +77,17 @@ for (const inPath of inPaths) {
     const outPath = path.resolve(inPath, '../..', language, newFilename)
 
     fs.writeFileSync(outPath, code)
-    console.error('wrote to', outPath)
+    if (printEachFile) {
+      console.error('wrote to', outPath)
+    } else {
+      total += 1
+    }
   }
 }
+if (!printEachFile) {
+  console.error('wrote', total, 'file' + (total === 1 ? '' : 's'))
+} 
+
 
 if (inPaths.length && languages.length) {
   console.error('Please carefully check all the output for correctness before committing.')

--- a/util.js
+++ b/util.js
@@ -941,25 +941,25 @@ const buildRequest = parsedArguments => {
   let cookieString
   if (parsedArguments.header) {
     if (!headers) {
-      headers = {}
+      headers = []
     }
     parsedArguments.header.forEach(header => {
+      const [name, value] = header.split(/:(.*)/s, 2)
       if (header.indexOf('Cookie') !== -1) {
         cookieString = header
       } else {
-        const components = header.split(/:(.*)/s)
-        if (components[1]) {
-          headers[components[0]] = components[1].trim()
-        }
+        headers.push([name, value ? value.replace(/^ /, '') : ''])
       }
     })
   }
 
   if (parsedArguments['user-agent']) {
     if (!headers) {
-      headers = {}
+      headers = []
     }
-    headers['User-Agent'] = parsedArguments['user-agent']
+    // TODO: headers are case insesitive
+    // detect prevalining case convention of other headers and match it
+    headers.push(['User-Agent', parsedArguments['user-agent']])
   }
 
   if (parsedArguments.cookie) {
@@ -1154,11 +1154,40 @@ const serializeCookies = cookieDict => {
   return cookieString
 }
 
+// Gets the first header, matching case-insensitively
+const getHeader = (request, header) => {
+  if (!request.headers) {
+    return undefined
+  }
+  const lookup = header.toLowerCase()
+  for (const [h, v] of request.headers) {
+    if (h.toLowerCase() === lookup) {
+      return v
+    }
+  }
+  return undefined
+}
+
+const hasHeader = (request, header) => {
+  if (!request.headers) {
+    return false
+  }
+  const lookup = header.toLowerCase()
+  for (const h of request.headers) {
+    if (h[0].toLowerCase() === lookup) {
+      return true
+    }
+  }
+  return false
+}
+
 export {
   curlLongOpts,
   curlShortOpts,
   parseArgs,
   buildRequest,
   parseCurlCommand,
-  serializeCookies
+  serializeCookies,
+  getHeader,
+  hasHeader
 }

--- a/util.js
+++ b/util.js
@@ -945,7 +945,8 @@ const buildRequest = parsedArguments => {
     }
     parsedArguments.header.forEach(header => {
       const [name, value] = header.split(/:(.*)/s, 2)
-      if (header.indexOf('Cookie') !== -1) {
+      if (name.toLowerCase().trim().startsWith('cookie') && value.trim()) {
+        // TODO: this will be overwritten if --cookie is passed
         cookieString = header
       } else {
         headers.push([name, value ? value.replace(/^ /, '') : ''])


### PR DESCRIPTION
to allow repeated headers, closes #70 

lookup headers case-insensitively, closes #89

Also add a system to the Python generator to comment out headers and use it to comment out Content-Type when it's `multipart/form-data`. Closes #248