### PR TITLE
handle backslashes in words

### DIFF
--- a/util.js
+++ b/util.js
@@ -589,11 +589,11 @@ const toBoolean = opt => {
   return true
 }
 
-// NOTE: this bash string parsing is probably not entirely correct.
-// We get the text as it appears in the bash source code,
-// which might have escaped newlines (if the string spans
-// multiple lines) and escaped quotes and maybe other
-// things I don't know about.
+const parseWord = (str) => {
+  const BACKSLASHES = /\\./gs
+  const unescapeChar = (m) => m.charAt(1) === '\n' ? '' : m.charAt(1)
+  return str.replace(BACKSLASHES, unescapeChar)
+}
 const parseSingleQuoteString = (str) => {
   const BACKSLASHES = /\\(\n|')/gs
   const unescapeChar = (m) => m.charAt(1) === '\n' ? '' : m.charAt(1)
@@ -738,15 +738,14 @@ const tokenizeBashStr = (curlCommand) => {
   const toVal = (node) => {
     switch (node.type) {
       case 'word':
-        return node.text
+      case 'simple_expansion': // TODO: handle variables properly downstream
+        return parseWord(node.text)
       case 'string':
         return parseDoubleQuoteString(node.text)
       case 'raw_string':
         return parseSingleQuoteString(node.text)
       case 'ansii_c_string':
         return parseAnsiCString(node.text)
-      case 'simple_expansion':
-        return node.text // TODO: handle variables properly downstream
       case 'concatenation':
         // item[]=1 turns into item=1 if we don't do this
         // https://github.com/tree-sitter/tree-sitter-bash/issues/104


### PR DESCRIPTION
Closes #34 

After #332, we generate PHP code using PHP's libcurl instead of Requests and it supports -F but but I noticed on that issue that `-F \[blah\]` will output code with the backslashes still in there, whereas [the bash manual says](https://www.gnu.org/software/bash/manual/bash.html#Escape-Character) that backslash in words only escapes newline characters. For example, `echo \\\a` will print literally `\a`.