### PR TITLE
build wasm on local npm install

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         # Tests fail to run on Windows, see
         # https://github.com/curlconverter/curlconverter/pull/310
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest]
         node-version: [12, 14, 16]
       fail-fast: false
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "test": "tape test.js",
     "lint": "standard",
     "lint:fix": "standard --fix",
-    "prepublishOnly": "tree-sitter build-wasm --docker node_modules/@curlconverter/tree-sitter-bash",
+    "prepare": "tree-sitter build-wasm --docker node_modules/@curlconverter/tree-sitter-bash",
     "gen-test": "./tools/gen-test.js",
     "compare-requests": "./tools/compare-requests.js",
     "compare-request": "./tools/compare-requests.js"


### PR DESCRIPTION
so that `curlconverter` can be installed from github, i.e. you can put this in packages.json

```json
    "curlconverter": "git+ssh://git@github.com/curlconverter/curlconverter.git",
```

and have that work.