### PR TITLE
add encode=form to R code when passed --data

### DIFF
--- a/src/generators/r.ts
+++ b/src/generators/r.ts
@@ -46,75 +46,6 @@ function getQueryDict(request: Request): string | undefined {
   return queryDict;
 }
 
-function getDataString(request: Request): string {
-  if (!request.data) {
-    return "";
-  }
-  if (!request.isDataRaw && request.data.startsWith("@")) {
-    const filePath = request.data.slice(1);
-    return "data = upload_file('" + filePath + "')";
-  }
-
-  const parsedQueryString = querystring.parse(request.data, { sort: false });
-  const keyCount = Object.keys(parsedQueryString).length;
-  const singleKeyOnly =
-    keyCount === 1 && !parsedQueryString[Object.keys(parsedQueryString)[0]];
-  const singularData = request.isDataBinary || singleKeyOnly;
-  if (singularData) {
-    return "data = " + repr(request.data) + "\n";
-  } else {
-    return getMultipleDataString(request, parsedQueryString);
-  }
-}
-
-function getMultipleDataString(
-  request: Request,
-  parsedQueryString: querystring.ParsedQuery<string>
-) {
-  let repeatedKey = false;
-  for (const key in parsedQueryString) {
-    const value = parsedQueryString[key];
-    if (Array.isArray(value)) {
-      repeatedKey = true;
-    }
-  }
-
-  let dataString;
-  if (repeatedKey) {
-    const els = [];
-    dataString = "data = list(\n";
-    for (const key in parsedQueryString) {
-      const value = parsedQueryString[key];
-      if (Array.isArray(value)) {
-        for (let i = 0; i < value.length; i++) {
-          const val = value[i];
-          els.push("  " + reprn(key) + " = " + repr(val === null ? "" : val));
-        }
-      } else {
-        els.push("  " + reprn(key) + " = " + repr(value === null ? "" : value));
-      }
-    }
-    dataString += els.join(",\n");
-    dataString += "\n)\n";
-  } else {
-    dataString = "data = list(\n";
-    dataString += Object.keys(parsedQueryString)
-      .map((key) => {
-        const value = parsedQueryString[key];
-        return (
-          "  " +
-          reprn(key) +
-          " = " +
-          repr(value === null ? "" : (value as string))
-        );
-      })
-      .join(",\n");
-    dataString += "\n)\n";
-  }
-
-  return dataString;
-}
-
 function getFilesString(request: Request): string | undefined {
   if (!request.multipartUploads) {
     return undefined;
@@ -169,9 +100,39 @@ export const _toR = (request: Request) => {
   const queryDict = getQueryDict(request);
 
   let dataString;
+  let dataIsList;
   let filesString;
   if (request.data) {
-    dataString = getDataString(request);
+    if (request.data.startsWith("@") && !request.isDataRaw) {
+      const filePath = request.data.slice(1);
+      dataString = "data = upload_file('" + filePath + "')";
+    } else {
+      const [parsedQueryString] = util.parseQueryString(request.data);
+      // repeat to satisfy type checker
+      dataIsList =
+        parsedQueryString &&
+        parsedQueryString.length &&
+        (parsedQueryString.length > 1 || parsedQueryString[0][1] !== null);
+      if (dataIsList) {
+        dataString = "data = list(\n";
+        dataString += (parsedQueryString as util.Query)
+          .map((q) => {
+            const [key, value] = q;
+            // Converting null to "" causes the generated code to send a different request,
+            // with a = where there was none. This is hopefully more useful though than just
+            // outputing the data as a string in the generated code.
+            // TODO: add the orginal data commented out as a string explaining the above
+            // situation.
+            return (
+              "  " + reprn(key) + " = " + repr(value === null ? "" : value)
+            );
+          })
+          .join(",\n");
+        dataString += "\n)\n";
+      } else {
+        dataString = "data = " + repr(request.data) + "\n";
+      }
+    }
   } else if (request.multipartUploads) {
     filesString = getFilesString(request);
   }
@@ -184,8 +145,20 @@ export const _toR = (request: Request) => {
     request.urlWithoutQuery = "http://" + request.urlWithoutQuery;
   }
   const url = request.queryDict ? request.urlWithoutQuery : request.url;
-  let requestLine =
-    "res <- httr::" + request.method.toUpperCase() + "(url = '" + url + "'";
+
+  let requestLine = "res <- httr::";
+
+  // TODO: GET() doesn't support sending data, detect and use VERB() instead
+  if (
+    ["GET", "HEAD", "PATCH", "PUT", "DELETE", "POST"].includes(
+      request.method.toUpperCase()
+    )
+  ) {
+    requestLine += request.method.toUpperCase() + "(";
+  } else {
+    requestLine += "VERB(" + repr(request.method) + ", ";
+  }
+  requestLine += "url = '" + url + "'";
 
   let requestLineBody = "";
   if (request.headers) {
@@ -197,10 +170,13 @@ export const _toR = (request: Request) => {
   if (request.cookies) {
     requestLineBody += ", httr::set_cookies(.cookies = cookies)";
   }
-  if (request.data && typeof request.data === "string") {
+  if (request.data) {
     requestLineBody += ", body = data";
+    if (dataIsList) {
+      requestLineBody += ", encode = 'form'";
+    }
   } else if (request.multipartUploads) {
-    requestLineBody += ", body = files";
+    requestLineBody += ", body = files, encode = 'multipart'";
   }
   if (request.insecure) {
     requestLineBody += ", config = httr::config(ssl_verifypeer = FALSE)";

--- a/src/generators/r.ts
+++ b/src/generators/r.ts
@@ -4,7 +4,6 @@ import * as util from "../util.js";
 import type { Request, Cookie, QueryDict } from "../util.js";
 
 import jsesc from "jsesc";
-import querystring from "query-string";
 
 function reprn(value: string | null): string {
   // back-tick quote names

--- a/test/fixtures/r/multipart_post.r
+++ b/test/fixtures/r/multipart_post.r
@@ -9,4 +9,4 @@ files = list(
   `file` = upload_file('myfile.jpg')
 )
 
-res <- httr::POST(url = 'https://localhost:28139/api/2.0/files/content', httr::add_headers(.headers=headers), body = files)
+res <- httr::POST(url = 'https://localhost:28139/api/2.0/files/content', httr::add_headers(.headers=headers), body = files, encode = 'multipart')

--- a/test/fixtures/r/multiple_d_post.r
+++ b/test/fixtures/r/multiple_d_post.r
@@ -4,11 +4,6 @@ headers = c(
   `Content-Type` = 'application/x-www-form-urlencoded'
 )
 
-data = list(
-  `version` = '1.2',
-  `auth_user` = 'fdgxf',
-  `auth_pwd` = 'oxfdscds',
-  `json_data` = '{ "operation": "core/get", "class": "Software", "key": "key" }'
-)
+data = 'version=1.2&auth_user=fdgxf&auth_pwd=oxfdscds&json_data={ "operation": "core/get", "class": "Software", "key": "key" }'
 
 res <- httr::POST(url = 'https://localhost:28139/webservices/rest.php', httr::add_headers(.headers=headers), body = data)

--- a/test/fixtures/r/options.r
+++ b/test/fixtures/r/options.r
@@ -24,4 +24,4 @@ params = list(
   `mediaOwnerCustomerId` = 'xxx'
 )
 
-res <- httr::OPTIONS(url = 'https://localhost:28139/api/tunein/queue-and-play', httr::add_headers(.headers=headers), query = params)
+res <- httr::VERB('OPTIONS', url = 'https://localhost:28139/api/tunein/queue-and-play', httr::add_headers(.headers=headers), query = params)

--- a/test/fixtures/r/post_basic_auth_url_encoded_data.r
+++ b/test/fixtures/r/post_basic_auth_url_encoded_data.r
@@ -8,4 +8,4 @@ data = list(
   `grant_type` = 'client_credentials'
 )
 
-res <- httr::POST(url = 'http://localhost:28139/api/oauth/token/', httr::add_headers(.headers=headers), body = data, httr::authenticate('foo', 'bar'))
+res <- httr::POST(url = 'http://localhost:28139/api/oauth/token/', httr::add_headers(.headers=headers), body = data, encode = 'form', httr::authenticate('foo', 'bar'))

--- a/test/fixtures/r/post_escaped_double_quotes_in_single_quotes.r
+++ b/test/fixtures/r/post_escaped_double_quotes_in_single_quotes.r
@@ -4,8 +4,6 @@ headers = c(
   `Content-Type` = 'application/x-www-form-urlencoded'
 )
 
-data = list(
-  `foo` = '\\"bar\\"'
-)
+data = 'foo=\\"bar\\"'
 
 res <- httr::POST(url = 'http://localhost:28139/', httr::add_headers(.headers=headers), body = data)

--- a/test/fixtures/r/post_escaped_single_quotes_in_double_quotes.r
+++ b/test/fixtures/r/post_escaped_single_quotes_in_double_quotes.r
@@ -4,8 +4,6 @@ headers = c(
   `Content-Type` = 'application/x-www-form-urlencoded'
 )
 
-data = list(
-  `foo` = '\\\'bar\\\''
-)
+data = 'foo=\\\'bar\\\''
 
 res <- httr::POST(url = 'http://localhost:28139/', httr::add_headers(.headers=headers), body = data)

--- a/test/fixtures/r/post_form.r
+++ b/test/fixtures/r/post_form.r
@@ -5,4 +5,4 @@ files = list(
   `password` = 'something'
 )
 
-res <- httr::POST(url = 'http://localhost:28139/post-to-me.php', body = files)
+res <- httr::POST(url = 'http://localhost:28139/post-to-me.php', body = files, encode = 'multipart')

--- a/test/fixtures/r/post_image.r
+++ b/test/fixtures/r/post_image.r
@@ -4,4 +4,4 @@ files = list(
   `image` = upload_file('image.jpg')
 )
 
-res <- httr::POST(url = 'http://localhost:28139/targetservice', body = files)
+res <- httr::POST(url = 'http://localhost:28139/targetservice', body = files, encode = 'multipart')

--- a/test/fixtures/r/post_quotes_inside_data.r
+++ b/test/fixtures/r/post_quotes_inside_data.r
@@ -8,4 +8,4 @@ data = list(
   `field` = 'don\'t you like quotes'
 )
 
-res <- httr::POST(url = 'http://localhost:28139', httr::add_headers(.headers=headers), body = data)
+res <- httr::POST(url = 'http://localhost:28139', httr::add_headers(.headers=headers), body = data, encode = 'form')

--- a/test/fixtures/r/post_same_field_multiple_times.r
+++ b/test/fixtures/r/post_same_field_multiple_times.r
@@ -10,4 +10,4 @@ data = list(
   `foo` = 'barbar'
 )
 
-res <- httr::POST(url = 'http://localhost:28139/', httr::add_headers(.headers=headers), body = data)
+res <- httr::POST(url = 'http://localhost:28139/', httr::add_headers(.headers=headers), body = data, encode = 'form')

--- a/test/fixtures/r/post_with_data_raw.r
+++ b/test/fixtures/r/post_with_data_raw.r
@@ -4,10 +4,6 @@ headers = c(
   `Content-Type` = 'application/x-www-form-urlencoded'
 )
 
-data = list(
-  `msg1` = 'wow',
-  `msg2` = 'such',
-  `msg3` = '@rawmsg'
-)
+data = 'msg1=wow&msg2=such&msg3=@rawmsg'
 
 res <- httr::POST(url = 'http://localhost:28139/post', httr::add_headers(.headers=headers), body = data)

--- a/test/fixtures/r/post_with_double_quotes_inside_single_quotes.r
+++ b/test/fixtures/r/post_with_double_quotes_inside_single_quotes.r
@@ -4,8 +4,6 @@ headers = c(
   `Content-Type` = 'application/x-www-form-urlencoded'
 )
 
-data = list(
-  `foo` = '"bar"'
-)
+data = 'foo="bar"'
 
 res <- httr::POST(url = 'http://localhost:28139/', httr::add_headers(.headers=headers), body = data)

--- a/test/fixtures/r/post_with_escaped_double_quotes.r
+++ b/test/fixtures/r/post_with_escaped_double_quotes.r
@@ -4,8 +4,6 @@ headers = c(
   `Content-Type` = 'application/x-www-form-urlencoded'
 )
 
-data = list(
-  `foo` = '"bar"'
-)
+data = 'foo="bar"'
 
 res <- httr::POST(url = 'http://localhost:28139/', httr::add_headers(.headers=headers), body = data)

--- a/test/fixtures/r/post_with_single_quotes_inside_double_quotes.r
+++ b/test/fixtures/r/post_with_single_quotes_inside_double_quotes.r
@@ -4,8 +4,6 @@ headers = c(
   `Content-Type` = 'application/x-www-form-urlencoded'
 )
 
-data = list(
-  `foo` = '\'bar\''
-)
+data = 'foo=\'bar\''
 
 res <- httr::POST(url = 'http://localhost:28139/', httr::add_headers(.headers=headers), body = data)

--- a/test/fixtures/r/post_with_urlencoded_data.r
+++ b/test/fixtures/r/post_with_urlencoded_data.r
@@ -17,4 +17,4 @@ data = list(
   `msg2` = 'such'
 )
 
-res <- httr::POST(url = 'http://localhost:28139/echo/html/', httr::add_headers(.headers=headers), body = data)
+res <- httr::POST(url = 'http://localhost:28139/echo/html/', httr::add_headers(.headers=headers), body = data, encode = 'form')

--- a/test/fixtures/r/post_with_urlencoded_data_and_headers.r
+++ b/test/fixtures/r/post_with_urlencoded_data_and_headers.r
@@ -35,4 +35,4 @@ data = list(
   `CurrentPage` = '1'
 )
 
-res <- httr::POST(url = 'http://localhost:28139/api/Listing.svc/PropertySearch_Post', httr::add_headers(.headers=headers), body = data)
+res <- httr::POST(url = 'http://localhost:28139/api/Listing.svc/PropertySearch_Post', httr::add_headers(.headers=headers), body = data, encode = 'form')

--- a/test/fixtures/r/strange_http_method.r
+++ b/test/fixtures/r/strange_http_method.r
@@ -1,3 +1,3 @@
 require(httr)
 
-res <- httr::WHAT(url = 'http://localhost:28139')
+res <- httr::VERB('wHat', url = 'http://localhost:28139')

--- a/tools/compare-requests.ts
+++ b/tools/compare-requests.ts
@@ -19,7 +19,7 @@ const awaitableExec = promisify(exec);
 const DEFAULT_PORT = 28139; // chosen randomly
 const EXPECTED_URL = "localhost:" + DEFAULT_PORT;
 
-// Only Python is supported currently.
+// Only Python and R are supported currently.
 const extension = {
   // ansible: 'yml',
   // browser: 'js',
@@ -32,7 +32,7 @@ const extension = {
   // node: 'js',
   // php: 'php',
   python: "py",
-  // r: 'R',
+  r: "r",
   // rust: 'rs',
   // strest: 'strest.yml'
 };
@@ -50,8 +50,8 @@ const executable = {
   // because curlconverter is an ES6 module.
   // node: 'node',
   // php: '',
-  python: "python3",
-  // r: '',
+  python: "python3 <file>",
+  r: "r < <file> --no-save",
   // rust: '',
   // strest: ''
 };
@@ -151,7 +151,7 @@ const testFile = async (testFilename: string): Promise<void> => {
       testFilename + "." + extension[language]
     );
     if (fs.existsSync(languageFile)) {
-      const command = executable[language] + " " + languageFile;
+      const command = executable[language].replace("<file>", languageFile);
       try {
         await awaitableExec(command);
       } catch (e) {


### PR DESCRIPTION
Closes #378

This replaces `querystring` with our own query string parsing, which unfortunately is a lot more restrictive so we won't be parsing lots of query strings we used to and just leaving them as a string now.