### PR TITLE
read cookies from file in Python

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -204,7 +204,7 @@ if (stdin) {
 } else {
   let request;
   try {
-    request = buildRequest(parsedArguments);
+    request = buildRequest(parsedArguments, warnings);
   } catch (e) {
     exitWithError(e, parsedArguments.verbose);
   }

--- a/src/generators/go.ts
+++ b/src/generators/go.ts
@@ -29,10 +29,10 @@ const reprMaybeBacktick = (s: string): string => {
   return s.includes('"') && !s.includes("`") ? reprBacktick(s) : repr(s);
 };
 const reprBacktick = (s: string): string => {
-  return "`" + s + "`";
+  return !s.includes("`") ? "`" + s + "`" : repr(s);
 };
 const repr = (s: string): string => {
-  return '"' + jsesc(s, { quotes: "double" }) + '"';
+  return '"' + jsesc(s, { quotes: "double", minimal: true }) + '"';
 };
 
 export const _toGo = (

--- a/src/util.ts
+++ b/src/util.ts
@@ -120,7 +120,7 @@ interface Request {
   auth?: [string, string];
   cookies?: Cookies;
   cookieFiles?: string[];
-
+  cookieJar?: string;
   compressed?: boolean;
   isDataBinary?: boolean;
   isDataRaw?: boolean;
@@ -1398,10 +1398,6 @@ function buildRequest(
         cookieStrings.push(c);
       } else {
         cookieFiles.push(c);
-        warnings.push([
-          "--cookie",
-          '"' + c + '" looks like a file to read cookies from, ignoring',
-        ]);
       }
     }
     if (cookieStrings.length) {
@@ -1517,8 +1513,14 @@ function buildRequest(
     // deleteHeader(request, 'cookie')
     request.cookies = cookies;
   }
+  // TODO: most generators support passing cookies with --cookie but don't
+  // support reading cookies from a file. We need to somehow warn users
+  // when that is the case.
   if (cookieFiles.length) {
     request.cookieFiles = cookieFiles;
+  }
+  if (parsedArguments["cookie-jar"]) {
+    request.cookieJar = parsedArguments["cookie-jar"];
   }
 
   if (parsedArguments.compressed) {

--- a/src/util.ts
+++ b/src/util.ts
@@ -119,6 +119,8 @@ interface Request {
   } & ({ content: string } | { contentFile: string; filename?: string }))[];
   auth?: [string, string];
   cookies?: Cookies;
+  cookieFiles?: string[];
+
   compressed?: boolean;
   isDataBinary?: boolean;
   isDataRaw?: boolean;
@@ -1348,7 +1350,11 @@ export function parseQueryString(
   return [asList, asDict];
 }
 
-function buildRequest(parsedArguments: ParsedArguments): Request {
+function buildRequest(
+  parsedArguments: ParsedArguments,
+  warnings?: Warnings
+): Request {
+  warnings = warnings || [];
   // TODO: handle multiple URLs
   if (!parsedArguments.url || !parsedArguments.url.length) {
     // TODO: better error message (could be parsing fail)
@@ -1376,16 +1382,29 @@ function buildRequest(parsedArguments: ParsedArguments): Request {
     headers.length > 0 && headers.every((h) => h[0] === h[0].toLowerCase());
 
   let cookies;
+  const cookieFiles: string[] = [];
   const cookieHeaders = headers.filter((h) => h[0].toLowerCase() === "cookie");
   if (cookieHeaders.length === 1 && cookieHeaders[0][1] !== null) {
     const parsedCookies = parseCookiesStrict(cookieHeaders[0][1]);
     if (parsedCookies) {
       cookies = parsedCookies;
     }
-  } else if (cookieHeaders.length === 0) {
+  } else if (cookieHeaders.length === 0 && parsedArguments.cookie) {
     // If there is a Cookie header, --cookies is ignored
-    if (parsedArguments.cookie) {
-      // TODO: a --cookie without a = character reads from it as a filename
+    const cookieStrings: string[] = [];
+    for (const c of parsedArguments.cookie) {
+      // a --cookie without a = character reads from it as a filename
+      if (c.includes("=")) {
+        cookieStrings.push(c);
+      } else {
+        cookieFiles.push(c);
+        warnings.push([
+          "--cookie",
+          '"' + c + '" looks like a file to read cookies from, ignoring',
+        ]);
+      }
+    }
+    if (cookieStrings.length) {
       const cookieString = parsedArguments.cookie.join(";");
       _setHeaderIfMissing(headers, "Cookie", cookieString, lowercase);
       cookies = parseCookies(cookieString);
@@ -1497,6 +1516,9 @@ function buildRequest(parsedArguments: ParsedArguments): Request {
     // generators that use .cookies need to do
     // deleteHeader(request, 'cookie')
     request.cookies = cookies;
+  }
+  if (cookieFiles.length) {
+    request.cookieFiles = cookieFiles;
   }
 
   if (parsedArguments.compressed) {
@@ -1693,7 +1715,7 @@ function parseCurlCommand(
     curlShortOpts,
     supportedArgs
   );
-  const request = buildRequest(parsedArguments);
+  const request = buildRequest(parsedArguments, warnings);
   if (stdin) {
     request.stdin = stdin;
   }

--- a/test/fixtures/curl_commands/get_cookies_from_file.sh
+++ b/test/fixtures/curl_commands/get_cookies_from_file.sh
@@ -1,0 +1,1 @@
+curl -b cookie.txt http://localhost:28139/

--- a/test/fixtures/parser/get_cookies_from_file.json
+++ b/test/fixtures/parser/get_cookies_from_file.json
@@ -1,0 +1,8 @@
+{
+  "url": "http://localhost:28139/",
+  "method": "GET",
+  "urlWithoutQuery": "http://localhost:28139/",
+  "cookieFiles": [
+    "cookie.txt"
+  ]
+}

--- a/test/fixtures/python/bash_redirect.py
+++ b/test/fixtures/python/bash_redirect.py
@@ -16,4 +16,4 @@ params = {
 with open('add_params.xml', 'rb') as f:
     data = f.read().replace(b'\n', b'')
 
-response = requests.post('https://localhost:28139/api/2.0/fo/auth/unix/', headers=headers, params=params, data=data, auth=('USER', 'PASS'))
+response = requests.post('https://localhost:28139/api/2.0/fo/auth/unix/', params=params, headers=headers, data=data, auth=('USER', 'PASS'))

--- a/test/fixtures/python/get_charles_syntax.py
+++ b/test/fixtures/python/get_charles_syntax.py
@@ -11,4 +11,4 @@ params = {
     'format': 'json',
 }
 
-response = requests.get('http://localhost:28139/', headers=headers, params=params)
+response = requests.get('http://localhost:28139/', params=params, headers=headers)

--- a/test/fixtures/python/get_cookies_from_file.py
+++ b/test/fixtures/python/get_cookies_from_file.py
@@ -1,0 +1,7 @@
+import http
+
+import requests
+
+cookies = http.cookiejar.MozillaCookieJar('cookie.txt')
+
+response = requests.get('http://localhost:28139/', cookies=cookies)

--- a/test/fixtures/python/get_user_agent.py
+++ b/test/fixtures/python/get_user_agent.py
@@ -11,4 +11,4 @@ params = {
     'tkn': '817263812',
 }
 
-response = requests.get('http://localhost:28139/vc/moviesmagic', headers=headers, params=params)
+response = requests.get('http://localhost:28139/vc/moviesmagic', params=params, headers=headers)

--- a/test/fixtures/python/get_user_agent_alias.py
+++ b/test/fixtures/python/get_user_agent_alias.py
@@ -11,4 +11,4 @@ params = {
     'tkn': '817263812',
 }
 
-response = requests.get('http://localhost:28139/vc/moviesmagic', headers=headers, params=params)
+response = requests.get('http://localhost:28139/vc/moviesmagic', params=params, headers=headers)

--- a/test/fixtures/python/get_with_browser_headers.py
+++ b/test/fixtures/python/get_with_browser_headers.py
@@ -20,4 +20,4 @@ headers = {
     'Connection': 'keep-alive',
 }
 
-response = requests.get('http://localhost:28139/', headers=headers, cookies=cookies)
+response = requests.get('http://localhost:28139/', cookies=cookies, headers=headers)

--- a/test/fixtures/python/get_with_data.py
+++ b/test/fixtures/python/get_with_data.py
@@ -10,4 +10,4 @@ params = {
     'w': '4',
 }
 
-response = requests.get('http://localhost:28139/synthetics/api/v3/monitors', headers=headers, params=params)
+response = requests.get('http://localhost:28139/synthetics/api/v3/monitors', params=params, headers=headers)

--- a/test/fixtures/python/get_with_data2.py
+++ b/test/fixtures/python/get_with_data2.py
@@ -10,4 +10,4 @@ params = {
     'channel_ids': 'channel_id',
 }
 
-response = requests.put('http://localhost:28139/v2/alerts_policy_channels.json', headers=headers, params=params)
+response = requests.put('http://localhost:28139/v2/alerts_policy_channels.json', params=params, headers=headers)

--- a/test/fixtures/python/get_with_env_var.py
+++ b/test/fixtures/python/get_with_env_var.py
@@ -1,4 +1,5 @@
 import os
+
 import requests
 
 DO_API_TOKEN = os.getenv('DO_API_TOKEN')
@@ -12,4 +13,4 @@ params = {
     'type': 'distribution',
 }
 
-response = requests.get('http://localhost:28139/v2/images', headers=headers, params=params)
+response = requests.get('http://localhost:28139/v2/images', params=params, headers=headers)

--- a/test/fixtures/python/get_with_header_lowercase_cookie.py
+++ b/test/fixtures/python/get_with_header_lowercase_cookie.py
@@ -13,4 +13,4 @@ headers = {
     # 'cookie': 'secure_user_id=InNlY3VyZTEwNjI3Ig%3D%3D--3b5df49345735791f2b80eddafb630cdcba76a1d; adaptive_image=1440; has_js=1; ccShowCookieIcon=no; _web_session=Y2h...e5',
 }
 
-response = requests.get('http://localhost:28139/page', headers=headers, cookies=cookies)
+response = requests.get('http://localhost:28139/page', cookies=cookies, headers=headers)

--- a/test/fixtures/python/options.py
+++ b/test/fixtures/python/options.py
@@ -24,4 +24,4 @@ params = {
     'mediaOwnerCustomerId': 'xxx',
 }
 
-response = requests.options('https://localhost:28139/api/tunein/queue-and-play', headers=headers, params=params)
+response = requests.options('https://localhost:28139/api/tunein/queue-and-play', params=params, headers=headers)

--- a/test/fixtures/python/post_data_binary_with_equals.py
+++ b/test/fixtures/python/post_data_binary_with_equals.py
@@ -96,4 +96,4 @@ json_data = {
     },
 }
 
-response = requests.post('http://localhost:28139/api/service.svc', headers=headers, params=params, cookies=cookies, json=json_data)
+response = requests.post('http://localhost:28139/api/service.svc', params=params, cookies=cookies, headers=headers, json=json_data)

--- a/test/fixtures/python/post_with_browser_headers.py
+++ b/test/fixtures/python/post_with_browser_headers.py
@@ -19,4 +19,4 @@ headers = {
     # 'Content-Length': '0',
 }
 
-response = requests.post('http://localhost:28139/ajax/demo_post.asp', headers=headers, cookies=cookies)
+response = requests.post('http://localhost:28139/ajax/demo_post.asp', cookies=cookies, headers=headers)

--- a/test/fixtures/python/read_stdin.py
+++ b/test/fixtures/python/read_stdin.py
@@ -1,4 +1,5 @@
 import sys
+
 import requests
 
 headers = {


### PR DESCRIPTION
 and silently ignore the `--cookie` argument when it's a file in other generators, which is bad but better than what we were doing before (generating broken code).

Closes #199