### PR TITLE
Update php.ts, now have PHP ending symbol

### DIFF
--- a/src/generators/php/php.ts
+++ b/src/generators/php/php.ts
@@ -151,8 +151,8 @@ export const _toPhp = (request: Request, warnings: Warnings = []): string => {
   }
 
   phpCode += "\n$response = curl_exec($ch);\n\n";
-
   phpCode += "curl_close($ch);\n";
+  phpCode += "?>"
   return phpCode;
 };
 


### PR DESCRIPTION
There is no PHP ending symbol `?>` in old version, so I add it.

Thanks for merge my pull request!