### PR TITLE
--data-urlencode implies POST

### DIFF
--- a/src/generators/javascript/axios.ts
+++ b/src/generators/javascript/axios.ts
@@ -149,23 +149,8 @@ const buildConfigObject = (
         code += "    // data: " + commentedOutDataString + ",\n";
       }
       code += "    data: " + dataString + ",\n";
-
-      // OPTIONS is the only other http method that sends data
-      if (method !== "options") {
-        warnings.push([
-          "no-data-method",
-          "axios doesn't send data: with " + method + " requests",
-        ]);
-      }
     } else if (request.multipartUploads) {
       code += "    data: form,\n";
-
-      if (method !== "options") {
-        warnings.push([
-          "no-data-method",
-          "axios doesn't send data: with " + method + " requests",
-        ]);
-      }
     }
   }
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -1283,15 +1283,13 @@ const parseArgs = (
         }
       } else {
         // Short option. These can look like
-        // -X POST -> {request: 'POST'}
+        // -X POST    -> {request: 'POST'}
         // or
-        // -XPOST  -> {request: 'POST'}
+        // -XPOST     -> {request: 'POST'}
         // or multiple options
-        // -ABCX POST
-        // -> {A: true, B: true, C: true, request: 'POST'}
+        // -ABCX POST -> {A: true, B: true, C: true, request: 'POST'}
         // or multiple options and a value for the last one
-        // -ABCXPOST
-        // -> {A: true, B: true, C: true, request: 'POST'}
+        // -ABCXPOST  -> {A: true, B: true, C: true, request: 'POST'}
 
         // "-" passed to curl as an argument raises an error,
         // curlconverter's command line uses it to read from stdin
@@ -1533,18 +1531,20 @@ function buildRequest(
     method = "HEAD";
   } else if (
     has(parsedArguments, "request") &&
+    // Safari adds `-X null` if it can't determine the request type
+    // https://github.com/WebKit/WebKit/blob/f58ef38d48f42f5d7723691cb090823908ff5f9f/Source/WebInspectorUI/UserInterface/Models/Resource.js#L1250
     parsedArguments.request !== "null"
   ) {
-    // Safari adds `-Xnull` if it can't determine the request type
     method = parsedArguments.request as string;
   } else if (parsedArguments["upload-file"]) {
     // --upload-file '' doesn't do anything.
     method = "PUT";
   } else if (
     (has(parsedArguments, "data") ||
-      has(parsedArguments, "data-ascii") ||
       has(parsedArguments, "data-binary") ||
+      has(parsedArguments, "data-ascii") ||
       has(parsedArguments, "data-raw") ||
+      has(parsedArguments, "data-urlencode") ||
       has(parsedArguments, "form") ||
       has(parsedArguments, "json")) &&
     !parsedArguments.get


### PR DESCRIPTION
also remove incorrect warning. [The documentation](https://axios-http.com/docs/req_config) saying that data: is "Only applicable for request methods 'PUT', 'POST', 'DELETE', and 'PATCH'" is just a suggestion, it still sends the data.