### PR TITLE
Preserve numbers in JSON that don't fit into f64

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@curlconverter/tree-sitter-bash": "^0.0.2",
         "jsesc": "^3.0.2",
+        "lossless-json": "^2.0.2",
         "tree-sitter": "^0.20.1",
         "web-tree-sitter": "^0.20.7",
         "yamljs": "^0.3.0"
@@ -2796,6 +2797,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/lossless-json": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/lossless-json/-/lossless-json-2.0.2.tgz",
+      "integrity": "sha512-lDh7OFGH0AfKlKmvbKLDIGlxdWl/5/ClZ4RaT7Zja3wraA3ynxWgZU6iD049eTcoyRJMHTekHqsOCFFWjTH6Cg=="
     },
     "node_modules/lru-cache": {
       "version": "6.0.0",
@@ -6721,6 +6727,11 @@
           }
         }
       }
+    },
+    "lossless-json": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/lossless-json/-/lossless-json-2.0.2.tgz",
+      "integrity": "sha512-lDh7OFGH0AfKlKmvbKLDIGlxdWl/5/ClZ4RaT7Zja3wraA3ynxWgZU6iD049eTcoyRJMHTekHqsOCFFWjTH6Cg=="
     },
     "lru-cache": {
       "version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "@curlconverter/tree-sitter-bash": "^0.0.2",
     "jsesc": "^3.0.2",
+    "lossless-json": "^2.0.2",
     "tree-sitter": "^0.20.1",
     "web-tree-sitter": "^0.20.7",
     "yamljs": "^0.3.0"


### PR DESCRIPTION
This allows doing this without losing parts of the number

```sh
curl example.com --json '{"a": 11111111111111111111111111111111111111111111}'
```