### PR TITLE
Python --location and --location-trusted

### DIFF
--- a/src/generators/php/php.ts
+++ b/src/generators/php/php.ts
@@ -35,6 +35,9 @@ const supportedArgs = new Set([
   "proxy",
   "max-time",
   "location",
+  "no-location",
+  // "location-trusted",
+  // "no-location-trusted",
 ]);
 
 // https://www.php.net/manual/en/language.types.string.php
@@ -42,10 +45,10 @@ const supportedArgs = new Set([
 // https://www.unicode.org/reports/tr44/#GC_Values_Table
 // https://unicode.org/Public/UNIDATA/UnicodeData.txt
 // https://en.wikipedia.org/wiki/Plane_(Unicode)#Overview
-const regexSinglEscape = /'|\\/gu;
+const regexSingleEscape = /'|\\/gu;
 const regexDoubleEscape = /"|\$|\\|\p{C}|\p{Z}/gu;
 export const repr = (s: string): string => {
-  let [quote, regex] = ["'", regexSinglEscape];
+  let [quote, regex] = ["'", regexSingleEscape];
   if ((s.includes("'") && !s.includes('"')) || /[^\x20-\x7E]/.test(s)) {
     [quote, regex] = ['"', regexDoubleEscape];
   }

--- a/src/generators/rust.ts
+++ b/src/generators/rust.ts
@@ -28,7 +28,9 @@ const supportedArgs = new Set([
   "no-basic",
   "oauth2-bearer",
   "location",
-  "location-trusted",
+  "no-location",
+  // "location-trusted",
+  // "no-location-trusted",
   "max-redirs",
 ]);
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -196,6 +196,13 @@ function setArgValue(
         config.authtype = CURLAUTH_ANY;
       }
       break;
+    case "location":
+      config["location"] = toggle;
+      break;
+    case "location-trusted":
+      config["location"] = toggle;
+      config["location-trusted"] = toggle;
+      break;
     default:
       config[argName] = toggle;
   }
@@ -237,6 +244,7 @@ interface Request {
   timeout?: string;
   connectTimeout?: string;
   followRedirects?: boolean;
+  followRedirectsTrusted?: boolean;
   maxRedirects?: string;
   output?: string;
   http2?: boolean;
@@ -2032,8 +2040,11 @@ function buildRequest(
     }
     request.connectTimeout = parsedArguments["connect-timeout"];
   }
-  if (parsedArguments.location || parsedArguments["location-trusted"]) {
-    request.followRedirects = true;
+  if (Object.prototype.hasOwnProperty.call(parsedArguments, "location")) {
+    request.followRedirects = parsedArguments.location;
+  }
+  if (parsedArguments["location-trusted"]) {
+    request.followRedirectsTrusted = parsedArguments["location-trusted"];
   }
   if (parsedArguments["max-redirs"]) {
     if (isNaN(parseInt(parsedArguments["max-redirs"]))) {


### PR DESCRIPTION
On the one hand, for `curl httpbin.org/status/301` the correct conversion is

```py
import requests

response = requests.get('http://httpbin.org/status/301', allow_redirects=False)
```

and the simpler code currently being generated

```py
import requests

response = requests.get('http://httpbin.org/status/301')
```

is only correct for `curl httpbin.org/status/301 --location`.

But on the other hand, this only makes a difference when the page redirects, which happens all the time but is relatively rare and more importantly it's cleaner to not have it, this program is the first thing users see when they open the website and making it harder to read will confuse people, especially if they don't know Python.