### PR TITLE
Go: comment out header to keep auto-decompression

### DIFF
--- a/src/generators/go.ts
+++ b/src/generators/go.ts
@@ -98,8 +98,22 @@ export const _toGo = (request: Request, warnings: Warnings = []): string => {
 
   if (request.headers) {
     for (const [headerName, headerValue] of request.headers || []) {
+      let start = "\t";
+      if (
+        headerName.toLowerCase() === "accept-encoding" &&
+        // By default Go will automatically decompress gzip,
+        // unless you set DisableCompression to true on the Transport
+        // or pass a custom Accept-Encoding header.
+        // By default curl won't automatically decompress gzip unless
+        // you pass --compressed, but we comment out the header in that
+        // case (request.compressed = undefined) too.
+        request.compressed !== false
+      ) {
+        start += "// ";
+      }
       goCode +=
-        "\treq.Header.Set(" +
+        start +
+        "req.Header.Set(" +
         repr(headerName) +
         ", " +
         reprMaybeBacktick(headerValue ?? "") +

--- a/src/generators/python.ts
+++ b/src/generators/python.ts
@@ -20,7 +20,7 @@ const supportedArgs = new Set([
   ...util.COMMON_SUPPORTED_ARGS,
 
   "compressed",
-  "no-compressed",
+  // "no-compressed",
 
   // "anyauth",
   // "no-anyauth",

--- a/test/fixtures/go/get_with_browser_headers.go
+++ b/test/fixtures/go/get_with_browser_headers.go
@@ -13,7 +13,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	req.Header.Set("Accept-Encoding", "gzip, deflate, sdch")
+	// req.Header.Set("Accept-Encoding", "gzip, deflate, sdch")
 	req.Header.Set("Accept-Language", "en-US,en;q=0.8")
 	req.Header.Set("User-Agent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.95 Safari/537.36")
 	req.Header.Set("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8")


### PR DESCRIPTION
[The net/http documentation](https://pkg.go.dev/net/http#Transport), says that it will automatically send `accept-encoding: gzip` and then decompress the response, unless you disable it by passing `DisableCompression: true` to the `Transport` or by manually setting the `Accept-Encoding` header.

```go
	// DisableCompression, if true, prevents the Transport from
	// requesting compression with an "Accept-Encoding: gzip"
	// request header when the Request contains no existing
	// Accept-Encoding value. If the Transport requests gzip on
	// its own and gets a gzipped response, it's transparently
	// decoded in the Response.Body. However, if the user
	// explicitly requested gzip it is not automatically
	// uncompressed.
	DisableCompression bool
```

I think the best way to solve this is to comment out the `Accept-Encoding` header in the generated code, unless we see `--no-compressed`.

We have 3 cases

`curl localhost:8888 --compressed` (enables decompression)

```
GET / HTTP/1.1
Host: localhost:8888
User-Agent: curl/7.86.0
Accept: */*
Accept-Encoding: deflate, gzip, br, zstd
```

`curl localhost:8888` (prints compressed data as-is)
`curl localhost:8888 --no-compressed`  (prints compressed data as-is)

```
GET / HTTP/1.1
Host: localhost:8888
User-Agent: curl/7.86.0
Accept: */*
```

The last 2 are the same for curl but I think we should treat them differently, we should actually keep decompression on (by commenting out the header) for the default case, even though it's a different behavior from the curl command because I would imagine most Go programmers want to decode gzip and to me it makes a bit more sense that `curl example.com` should convert to do the default thing on the runtime that we're converting to, so that the code generated for the simplest command is simpler. I made the same design choice for `--location`/`--no-location` and `allow_redirects=False` for Python.