### PR TITLE
Refactor Query.js to allow specific runtime/library percent encodes

### DIFF
--- a/src/Request.ts
+++ b/src/Request.ts
@@ -287,7 +287,8 @@ function buildURL(
   let urlWithoutQueryList = url;
   // TODO: parseQueryString() doesn't accept leading '?'
   let [queryList, queryDict] = parseQueryString(
-    u.query.toBool() ? u.query.slice(1) : new Word()
+    u.query.toBool() ? u.query.slice(1) : new Word(),
+    null
   );
   if (queryList && queryList.length) {
     // TODO: remove the fragment too?

--- a/src/generators/ansible.ts
+++ b/src/generators/ansible.ts
@@ -4,6 +4,7 @@ import type { Request, Warnings } from "../parse.js";
 import { parseQueryString, type QueryList, type QueryDict } from "../Query.js";
 
 import yaml from "yamljs";
+import { fileURLToPath } from "url";
 
 const supportedArgs = new Set([
   ...COMMON_SUPPORTED_ARGS,
@@ -142,7 +143,10 @@ function getDataString(
       }
       return [filename, "src"];
     }
-    const [queryList, queryDict] = parseQueryString(request.data);
+    const [queryList, queryDict] = parseQueryString(
+      request.data,
+      fileURLToPath(import.meta.url)
+    );
     if (queryDict) {
       return [
         Object.fromEntries(

--- a/src/generators/clojure.ts
+++ b/src/generators/clojure.ts
@@ -11,6 +11,7 @@ import { parseQueryString } from "../Query.js";
 // "Clojure strings are Java Strings."
 // https://clojure.org/reference/data_structures#Strings
 import { reprStr } from "./java/java.js";
+import { fileURLToPath } from "url";
 
 const supportedArgs = new Set([
   ...COMMON_SUPPORTED_ARGS,
@@ -241,7 +242,10 @@ function addDataString(
   }
 
   if (contentType === "application/x-www-form-urlencoded") {
-    const [queryList, queryDict] = parseQueryString(data);
+    const [queryList, queryDict] = parseQueryString(
+      data,
+      fileURLToPath(import.meta.url)
+    );
     const formParams = rerpQuery(queryList, queryDict, importLines);
     if (formParams !== null) {
       if (eq(exactContentType, "application/x-www-form-urlencoded")) {

--- a/src/generators/dart.ts
+++ b/src/generators/dart.ts
@@ -4,6 +4,7 @@ import type { Request, Warnings } from "../parse.js";
 import { parseQueryString } from "../Query.js";
 
 import { esc as jsesc } from "./javascript/javascript.js";
+import { fileURLToPath } from "url";
 
 const supportedArgs = new Set([
   ...COMMON_SUPPORTED_ARGS,
@@ -120,7 +121,10 @@ export function _toDart(requests: Request[], warnings: Warnings = []): string {
 
   const hasData = request.data;
   if (request.data) {
-    const [parsedQuery] = parseQueryString(request.data);
+    const [parsedQuery] = parseQueryString(
+      request.data,
+      fileURLToPath(import.meta.url)
+    );
     if (parsedQuery && parsedQuery.length) {
       s += "  final data = {\n";
       for (const param of parsedQuery) {

--- a/src/generators/elixir.ts
+++ b/src/generators/elixir.ts
@@ -3,6 +3,7 @@ import { Word, joinWords } from "../shell/Word.js";
 import { parse, COMMON_SUPPORTED_ARGS } from "../parse.js";
 import type { Request, Warnings } from "../parse.js";
 import { parseQueryString } from "../Query.js";
+import { fileURLToPath } from "url";
 
 const supportedArgs = new Set([
   ...COMMON_SUPPORTED_ARGS,
@@ -231,7 +232,10 @@ function getDataString(request: Request): string {
     }
   }
 
-  const [parsedQuery] = parseQueryString(request.data);
+  const [parsedQuery] = parseQueryString(
+    request.data,
+    fileURLToPath(import.meta.url)
+  );
   if (parsedQuery && parsedQuery.length) {
     const data = parsedQuery.map((p) => {
       const [key, value] = p;

--- a/src/generators/har.ts
+++ b/src/generators/har.ts
@@ -4,6 +4,7 @@ import { parse, COMMON_SUPPORTED_ARGS } from "../parse.js";
 import type { Request, RequestUrl, Warnings } from "../parse.js";
 import { parseQueryString } from "../Query.js";
 import type { Request as HARRequest, PostData as PostData } from "har-format";
+import { fileURLToPath } from "url";
 
 const supportedArgs = new Set([
   ...COMMON_SUPPORTED_ARGS,
@@ -31,7 +32,10 @@ function getDataString(request: Request): PostData | null {
   const mimeType = request.headers.getContentType() || "";
   try {
     // TODO: look at dataArray and generate fileName:
-    const [parsedQuery] = parseQueryString(request.data);
+    const [parsedQuery] = parseQueryString(
+      request.data,
+      fileURLToPath(import.meta.url)
+    );
     if (parsedQuery && parsedQuery.length) {
       return {
         mimeType,

--- a/src/generators/httpie.ts
+++ b/src/generators/httpie.ts
@@ -7,6 +7,7 @@ import { Headers } from "../Headers.js";
 import { parseQueryString } from "../Query.js";
 
 import { repr, reprStr } from "./wget.js";
+import { fileURLToPath } from "url";
 
 const supportedArgs = new Set([
   ...COMMON_SUPPORTED_ARGS,
@@ -185,7 +186,7 @@ function escapeQueryValue(value: Word): Word {
 function urlencodedAsHttpie(flags: string[], items: string[], data: Word) {
   let queryList;
   try {
-    [queryList] = parseQueryString(data);
+    [queryList] = parseQueryString(data, fileURLToPath(import.meta.url));
   } catch {}
   if (!queryList) {
     flags.push("--raw " + (repr(data) || "''"));

--- a/src/generators/java/okhttp.ts
+++ b/src/generators/java/okhttp.ts
@@ -4,6 +4,7 @@ import type { Request, Warnings } from "../../parse.js";
 import { parseQueryString } from "../../Query.js";
 
 import { repr } from "./java.js";
+import { fileURLToPath } from "url";
 
 const supportedArgs = new Set([
   ...COMMON_SUPPORTED_ARGS,
@@ -107,7 +108,10 @@ export function _toJavaOkHttp(
   } else if (request.data) {
     const contentType = request.headers.getContentType();
     if (contentType === "application/x-www-form-urlencoded") {
-      const [queryList] = parseQueryString(request.data);
+      const [queryList] = parseQueryString(
+        request.data,
+        fileURLToPath(import.meta.url)
+      );
       if (!queryList) {
         methodCallArgs.push("requestBody");
         javaCode +=

--- a/src/generators/javascript/axios.ts
+++ b/src/generators/javascript/axios.ts
@@ -15,6 +15,7 @@ import {
   addImport,
   reprImports,
 } from "./javascript.js";
+import { fileURLToPath } from "url";
 
 const supportedArgs = new Set([
   ...COMMON_SUPPORTED_ARGS,
@@ -60,7 +61,10 @@ function _getDataString(
     return [jsonAsJavaScript, roundtrips ? null : originalStringRepr];
   }
   if (contentType === "application/x-www-form-urlencoded") {
-    const [queryList, queryDict] = parseQueryString(request.data);
+    const [queryList, queryDict] = parseQueryString(
+      request.data,
+      fileURLToPath(import.meta.url)
+    );
     if (queryList) {
       // Technically axios sends
       // application/x-www-form-urlencoded;charset=utf-8

--- a/src/generators/javascript/got.ts
+++ b/src/generators/javascript/got.ts
@@ -15,6 +15,7 @@ import {
   addImport,
   bySecondElem,
 } from "./javascript.js";
+import { fileURLToPath } from "url";
 
 const supportedArgs = new Set([
   ...COMMON_SUPPORTED_ARGS,
@@ -80,7 +81,10 @@ function getBodyString(
       return [jsonAsJavaScript, roundtrips ? null : simpleString];
     }
     if (contentType === "application/x-www-form-urlencoded") {
-      const [queryList, queryDict] = parseQueryString(request.data);
+      const [queryList, queryDict] = parseQueryString(
+        request.data,
+        fileURLToPath(import.meta.url)
+      );
       if (queryDict && queryDict.every((v) => !Array.isArray(v[1]))) {
         if (eq(exactContentType, "application/x-www-form-urlencoded")) {
           request.headers.delete("content-type");

--- a/src/generators/javascript/http.ts
+++ b/src/generators/javascript/http.ts
@@ -13,6 +13,7 @@ import {
 } from "./javascript.js";
 
 import { dedent, getFormString } from "./jquery.js";
+import { fileURLToPath } from "url";
 
 const supportedArgs = new Set([
   ...COMMON_SUPPORTED_ARGS,
@@ -41,7 +42,7 @@ function _getDataString(
     return [jsonAsJavaScript, roundtrips ? null : originalStringRepr];
   }
   if (contentType === "application/x-www-form-urlencoded") {
-    const query = parseQueryString(data);
+    const query = parseQueryString(data, fileURLToPath(import.meta.url));
     if (query[0]) {
       // if (
       //   eq(exactContentType, "application/x-www-form-urlencoded; charset=utf-8")

--- a/src/generators/javascript/javascript.ts
+++ b/src/generators/javascript/javascript.ts
@@ -7,6 +7,7 @@ import type { QueryList, QueryDict } from "../../Query.js";
 import type { FormParam } from "../../curl/form.js";
 
 import jsescObj from "jsesc";
+import { fileURLToPath } from "url";
 
 const javaScriptSupportedArgs = new Set([
   ...COMMON_SUPPORTED_ARGS,
@@ -438,7 +439,10 @@ function getDataString(
   }
   if (contentType === "application/x-www-form-urlencoded") {
     try {
-      const [queryList, queryDict] = parseQueryString(data);
+      const [queryList, queryDict] = parseQueryString(
+        data,
+        fileURLToPath(import.meta.url)
+      );
       if (queryList) {
         // Technically node-fetch sends
         // application/x-www-form-urlencoded;charset=utf-8

--- a/src/generators/javascript/jquery.ts
+++ b/src/generators/javascript/jquery.ts
@@ -13,6 +13,7 @@ import {
   addImport,
   reprImports,
 } from "./javascript.js";
+import { fileURLToPath } from "url";
 
 const supportedArgs = new Set([
   ...COMMON_SUPPORTED_ARGS,
@@ -105,7 +106,10 @@ function _getDataString(
     ];
   }
   if (contentType === "application/x-www-form-urlencoded") {
-    const [queryList, queryDict] = parseQueryString(data);
+    const [queryList, queryDict] = parseQueryString(
+      data,
+      fileURLToPath(import.meta.url)
+    );
     if (queryList) {
       if (
         eq(exactContentType, "application/x-www-form-urlencoded; charset=utf-8")

--- a/src/generators/javascript/ky.ts
+++ b/src/generators/javascript/ky.ts
@@ -18,6 +18,7 @@ import {
 } from "./javascript.js";
 
 import { getFormString } from "./jquery.js";
+import { fileURLToPath } from "url";
 
 const supportedArgs = new Set([
   ...COMMON_SUPPORTED_ARGS,
@@ -58,7 +59,10 @@ function getDataString(
   }
   if (contentType === "application/x-www-form-urlencoded") {
     try {
-      const [queryList, queryDict] = parseQueryString(data);
+      const [queryList, queryDict] = parseQueryString(
+        data,
+        fileURLToPath(import.meta.url)
+      );
       if (queryList) {
         // Technically node-fetch sends
         // application/x-www-form-urlencoded;charset=utf-8

--- a/src/generators/javascript/superagent.ts
+++ b/src/generators/javascript/superagent.ts
@@ -16,6 +16,7 @@ import {
 } from "./javascript.js";
 
 import { indent } from "./jquery.js";
+import { fileURLToPath } from "url";
 
 const supportedArgs = new Set([
   ...COMMON_SUPPORTED_ARGS,
@@ -112,7 +113,10 @@ function _getDataString(
     ];
   }
   if (contentType === "application/x-www-form-urlencoded") {
-    const [queryList, queryDict] = parseQueryString(request.data);
+    const [queryList, queryDict] = parseQueryString(
+      request.data,
+      fileURLToPath(import.meta.url)
+    );
     if (queryList) {
       exactContentType = null;
       const queryCode =

--- a/src/generators/javascript/xhr.ts
+++ b/src/generators/javascript/xhr.ts
@@ -13,6 +13,7 @@ import {
 } from "./javascript.js";
 
 import { dedent, getFormString } from "./jquery.js";
+import { fileURLToPath } from "url";
 
 const supportedArgs = new Set([
   ...COMMON_SUPPORTED_ARGS,
@@ -40,7 +41,10 @@ function _getDataString(
     return [jsonAsJavaScript, roundtrips ? null : originalStringRepr];
   }
   if (contentType === "application/x-www-form-urlencoded") {
-    const [queryList, queryDict] = parseQueryString(data);
+    const [queryList, queryDict] = parseQueryString(
+      data,
+      fileURLToPath(import.meta.url)
+    );
     if (queryList) {
       // TODO: check roundtrip, add a comment
       return [toURLSearchParams([queryList, queryDict], imports), null];

--- a/src/generators/json.ts
+++ b/src/generators/json.ts
@@ -2,6 +2,7 @@ import { parse, getFirst, COMMON_SUPPORTED_ARGS } from "../parse.js";
 import type { Request, Warnings } from "../parse.js";
 import type { AuthType } from "../Request.js";
 import { parseQueryString } from "../Query.js";
+import { fileURLToPath } from "url";
 
 const supportedArgs = new Set([
   ...COMMON_SUPPORTED_ARGS,
@@ -79,7 +80,10 @@ function getDataString(request: Request): {
     } catch (e) {}
   }
 
-  const [parsedQuery, parsedQueryDict] = parseQueryString(request.data);
+  const [parsedQuery, parsedQueryDict] = parseQueryString(
+    request.data,
+    fileURLToPath(import.meta.url)
+  );
   if (!parsedQuery || !parsedQuery.length) {
     // TODO: this is not a good API
     return {

--- a/src/generators/kotlin.ts
+++ b/src/generators/kotlin.ts
@@ -2,6 +2,7 @@ import { Word, eq } from "../shell/Word.js";
 import { parse, getFirst, COMMON_SUPPORTED_ARGS } from "../parse.js";
 import type { Request, Warnings } from "../parse.js";
 import { parseQueryString } from "../Query.js";
+import { fileURLToPath } from "url";
 
 const supportedArgs = new Set([
   ...COMMON_SUPPORTED_ARGS,
@@ -187,7 +188,10 @@ export function _toKotlin(
     imports.add("java.io.File");
   } else if (request.data) {
     if (contentType === "application/x-www-form-urlencoded") {
-      const [queryList] = parseQueryString(request.data);
+      const [queryList] = parseQueryString(
+        request.data,
+        fileURLToPath(import.meta.url)
+      );
       if (!queryList) {
         if (exactContentType) {
           kotlinCode +=

--- a/src/generators/php/guzzle.ts
+++ b/src/generators/php/guzzle.ts
@@ -4,6 +4,7 @@ import type { Request, Warnings } from "../../parse.js";
 import { parseQueryString } from "../../Query.js";
 
 import { reprStr, repr } from "./php.js";
+import { fileURLToPath } from "url";
 
 const supportedArgs = new Set([
   ...COMMON_SUPPORTED_ARGS,
@@ -234,7 +235,10 @@ export function _toPhpGuzzle(
     const contentType = request.headers.getContentType();
     if (contentType === "application/x-www-form-urlencoded") {
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const [_, queryAsDict] = parseQueryString(request.data);
+      const [_, queryAsDict] = parseQueryString(
+        request.data,
+        fileURLToPath(import.meta.url)
+      );
       if (queryAsDict) {
         options += "    'form_params' => [\n";
         for (const [name, value] of queryAsDict) {

--- a/src/generators/php/requests.ts
+++ b/src/generators/php/requests.ts
@@ -3,6 +3,7 @@ import type { Request, Warnings } from "../../parse.js";
 import { parseQueryString } from "../../Query.js";
 
 import { repr } from "./php.js";
+import { fileURLToPath } from "url";
 
 const supportedArgs = new Set([
   ...COMMON_SUPPORTED_ARGS,
@@ -48,7 +49,10 @@ export function _toPhpRequests(
 
   let dataString;
   if (request.data) {
-    const [parsedQueryString] = parseQueryString(request.data);
+    const [parsedQueryString] = parseQueryString(
+      request.data,
+      fileURLToPath(import.meta.url)
+    );
     dataString = "$data = array(\n";
     if (!parsedQueryString || !parsedQueryString.length) {
       dataString = "$data = " + repr(request.data) + ";";

--- a/src/generators/powershell.ts
+++ b/src/generators/powershell.ts
@@ -3,6 +3,7 @@ import { warnIfPartsIgnored } from "../Warnings.js";
 import { Word, eq } from "../shell/Word.js";
 import type { Request, RequestUrl, Warnings } from "../parse.js";
 import { parseQueryString } from "../Query.js";
+import { fileURLToPath } from "url";
 
 // https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_quoting_rules
 // https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_special_characters
@@ -238,7 +239,10 @@ function requestToPowershell(
     if (contentType === "application/x-www-form-urlencoded") {
       let queryList, queryDict;
       try {
-        [queryList, queryDict] = parseQueryString(request.data);
+        [queryList, queryDict] = parseQueryString(
+          request.data,
+          fileURLToPath(import.meta.url)
+        );
       } catch {}
       if (
         queryList &&

--- a/src/generators/r.ts
+++ b/src/generators/r.ts
@@ -5,6 +5,7 @@ import { wordDecodeURIComponent, parseQueryString } from "../Query.js";
 import type { QueryList } from "../Query.js";
 
 import { reprStr as pyrepr } from "./python.js";
+import { fileURLToPath } from "url";
 
 const supportedArgs = new Set([
   ...COMMON_SUPPORTED_ARGS,
@@ -175,7 +176,10 @@ export function _toR(requests: Request[], warnings: Warnings = []): string {
       const filePath = request.data.slice(1);
       dataString = "data = upload_file(" + repr(filePath) + ")";
     } else {
-      const [parsedQueryString] = parseQueryString(request.data);
+      const [parsedQueryString] = parseQueryString(
+        request.data,
+        fileURLToPath(import.meta.url)
+      );
       // repeat to satisfy type checker
       dataIsList = parsedQueryString && parsedQueryString.length;
       if (dataIsList) {

--- a/src/generators/ruby.ts
+++ b/src/generators/ruby.ts
@@ -4,6 +4,7 @@ import { Word, eq } from "../shell/Word.js";
 import { parse, COMMON_SUPPORTED_ARGS } from "../parse.js";
 import type { Request, Warnings } from "../parse.js";
 import { parseQueryString, type QueryDict } from "../Query.js";
+import { fileURLToPath } from "url";
 
 // https://ruby-doc.org/stdlib-2.7.0/libdoc/net/http/rdoc/Net/HTTP.html
 // https://github.com/ruby/net-http/tree/master/lib/net
@@ -255,7 +256,10 @@ function getDataString(request: Request): [string, boolean] {
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const [_, queryAsDict] = parseQueryString(request.data);
+  const [_, queryAsDict] = parseQueryString(
+    request.data,
+    fileURLToPath(import.meta.url)
+  );
   if (!request.isDataBinary && queryAsDict) {
     // If the original request contained %20, Ruby will encode them as "+"
     return ["req.set_form_data(" + queryToRubyDict(queryAsDict) + ")\n", false];

--- a/test/fixtures/json/j_patch_array.json
+++ b/test/fixtures/json/j_patch_array.json
@@ -6,6 +6,10 @@
         "Content-Type": "application/x-www-form-urlencoded"
     },
     "data": {
-        "item[]=1&item[]=2&item[]=3": ""
+        "item[]": [
+            "1",
+            "2",
+            "3"
+        ]
     }
 }

--- a/test/fixtures/json/multiple_d_post.json
+++ b/test/fixtures/json/multiple_d_post.json
@@ -6,6 +6,9 @@
         "Content-Type": "application/x-www-form-urlencoded"
     },
     "data": {
-        "version=1.2&auth_user=fdgxf&auth_pwd=oxfdscds&json_data={ \"operation\": \"core/get\", \"class\": \"Software\", \"key\": \"key\" }": ""
+        "version": "1.2",
+        "auth_user": "fdgxf",
+        "auth_pwd": "oxfdscds",
+        "json_data": "{ \"operation\": \"core/get\", \"class\": \"Software\", \"key\": \"key\" }"
     }
 }

--- a/test/fixtures/json/post_with_data_raw.json
+++ b/test/fixtures/json/post_with_data_raw.json
@@ -6,6 +6,8 @@
         "Content-Type": "application/x-www-form-urlencoded"
     },
     "data": {
-        "msg1=wow&msg2=such&msg3=@rawmsg": ""
+        "msg1": "wow",
+        "msg2": "such",
+        "msg3": "@rawmsg"
     }
 }


### PR DESCRIPTION
- Changed parseQueryString function from Query.js to allow specific runtime/library percent encodes.
- Added specific json percent encode