### PR TITLE
Refactor Query.js to allow specific runtime/library percent encodes

### DIFF
--- a/src/Query.ts
+++ b/src/Query.ts
@@ -34,6 +34,44 @@ function _percentEncode(s: string): string {
     .join("");
 }
 
+// If the query string doesn't round-trip, we cannot properly convert it.
+// TODO: this is a bit Python-specific, ideally we would check how each runtime/library
+// percent-encodes query strings. For example, a %27 character in the input query
+// string will be decoded to a ' but won't be re-encoded into a %27 by encodeURIComponent
+function _roundTripSupported(
+  key: Word,
+  val: Word,
+  decodedKey: Word,
+  decodedVal: Word
+): boolean {
+  const roundTripKey = percentEncode(decodedKey);
+  const roundTripVal = percentEncode(decodedVal);
+  // If the original data used %20 instead of + (what requests will send), that's close enough
+  return !(
+    (!eq(roundTripKey, key) && !eq(roundTripKey.replace(/%20/g, "+"), key)) ||
+    (!eq(roundTripVal, val) && !eq(roundTripVal.replace(/%20/g, "+"), val))
+  );
+}
+
+function getConversion(
+  generatorName: string | null,
+  key: Word,
+  val: Word
+): [Word, Word] | null {
+  if (generatorName === null) {
+    return null;
+  }
+  type GeneratorMap = { [key: string]: [Word, Word] };
+  const generatorMap: GeneratorMap = {
+    json: [key, val],
+  };
+
+  if (generatorMap[generatorName] == null) {
+    return null;
+  }
+  return generatorMap[generatorName];
+}
+
 export function percentEncode(s: Word): Word {
   const newTokens = [];
   for (const token of s.tokens) {
@@ -45,6 +83,7 @@ export function percentEncode(s: Word): Word {
   }
   return new Word(newTokens);
 }
+
 export function percentEncodePlus(s: Word): Word {
   const newTokens = [];
   for (const token of s.tokens) {
@@ -72,11 +111,13 @@ export function wordDecodeURIComponent(s: Word): Word {
 
 // if url is 'example.com?' the s is ''
 // if url is 'example.com'  the s is null
-export function parseQueryString(s: Word | null): Query {
+export function parseQueryString(
+  s: Word | null,
+  generatorName: string | null
+): Query {
   if (!s || s.isEmpty()) {
     return [null, null];
   }
-
   const asList: QueryList = [];
   for (const param of s.split("&")) {
     // Most software libraries don't let you distinguish between a=&b= and a&b,
@@ -101,20 +142,14 @@ export function parseQueryString(s: Word | null): Query {
       }
       throw e;
     }
-    // If the query string doesn't round-trip, we cannot properly convert it.
-    // TODO: this is a bit Python-specific, ideally we would check how each runtime/library
-    // percent-encodes query strings. For example, a %27 character in the input query
-    // string will be decoded to a ' but won't be re-encoded into a %27 by encodeURIComponent
-    const roundTripKey = percentEncode(decodedKey);
-    const roundTripVal = percentEncode(decodedVal);
-    // If the original data used %20 instead of + (what requests will send), that's close enough
-    if (
-      (!eq(roundTripKey, key) && !eq(roundTripKey.replace(/%20/g, "+"), key)) ||
-      (!eq(roundTripVal, val) && !eq(roundTripVal.replace(/%20/g, "+"), val))
-    ) {
+    const foundConversion = getConversion(generatorName, key, val);
+    if (foundConversion !== null) {
+      asList.push(foundConversion);
+    } else if (!_roundTripSupported(key, val, decodedKey, decodedVal)) {
       return [null, null];
+    } else {
+      asList.push([decodedKey, decodedVal]);
     }
-    asList.push([decodedKey, decodedVal]);
   }
 
   // Group keys

--- a/src/Request.ts
+++ b/src/Request.ts
@@ -287,7 +287,8 @@ function buildURL(
   let urlWithoutQueryList = url;
   // TODO: parseQueryString() doesn't accept leading '?'
   let [queryList, queryDict] = parseQueryString(
-    u.query.toBool() ? u.query.slice(1) : new Word()
+    u.query.toBool() ? u.query.slice(1) : new Word(),
+    null
   );
   if (queryList && queryList.length) {
     // TODO: remove the fragment too?

--- a/src/generators/ansible.ts
+++ b/src/generators/ansible.ts
@@ -5,6 +5,7 @@ import { parseQueryString, type QueryList, type QueryDict } from "../Query.js";
 
 import yaml from "yamljs";
 
+const generatorName = "ansible";
 const supportedArgs = new Set([
   ...COMMON_SUPPORTED_ARGS,
   "compressed",
@@ -142,7 +143,10 @@ function getDataString(
       }
       return [filename, "src"];
     }
-    const [queryList, queryDict] = parseQueryString(request.data);
+    const [queryList, queryDict] = parseQueryString(
+      request.data,
+      generatorName
+    );
     if (queryDict) {
       return [
         Object.fromEntries(

--- a/src/generators/clojure.ts
+++ b/src/generators/clojure.ts
@@ -12,6 +12,7 @@ import { parseQueryString } from "../Query.js";
 // https://clojure.org/reference/data_structures#Strings
 import { reprStr } from "./java/java.js";
 
+const generatorName = "clojure";
 const supportedArgs = new Set([
   ...COMMON_SUPPORTED_ARGS,
   "form",
@@ -241,7 +242,7 @@ function addDataString(
   }
 
   if (contentType === "application/x-www-form-urlencoded") {
-    const [queryList, queryDict] = parseQueryString(data);
+    const [queryList, queryDict] = parseQueryString(data, generatorName);
     const formParams = rerpQuery(queryList, queryDict, importLines);
     if (formParams !== null) {
       if (eq(exactContentType, "application/x-www-form-urlencoded")) {

--- a/src/generators/dart.ts
+++ b/src/generators/dart.ts
@@ -5,6 +5,7 @@ import { parseQueryString } from "../Query.js";
 
 import { esc as jsesc } from "./javascript/javascript.js";
 
+const generatorName = "dart";
 const supportedArgs = new Set([
   ...COMMON_SUPPORTED_ARGS,
   "compressed",
@@ -120,7 +121,7 @@ export function _toDart(requests: Request[], warnings: Warnings = []): string {
 
   const hasData = request.data;
   if (request.data) {
-    const [parsedQuery] = parseQueryString(request.data);
+    const [parsedQuery] = parseQueryString(request.data, generatorName);
     if (parsedQuery && parsedQuery.length) {
       s += "  final data = {\n";
       for (const param of parsedQuery) {

--- a/src/generators/elixir.ts
+++ b/src/generators/elixir.ts
@@ -4,6 +4,7 @@ import { parse, COMMON_SUPPORTED_ARGS } from "../parse.js";
 import type { Request, Warnings } from "../parse.js";
 import { parseQueryString } from "../Query.js";
 
+const generatorName = "elixir";
 const supportedArgs = new Set([
   ...COMMON_SUPPORTED_ARGS,
   "form",
@@ -231,7 +232,7 @@ function getDataString(request: Request): string {
     }
   }
 
-  const [parsedQuery] = parseQueryString(request.data);
+  const [parsedQuery] = parseQueryString(request.data, generatorName);
   if (parsedQuery && parsedQuery.length) {
     const data = parsedQuery.map((p) => {
       const [key, value] = p;

--- a/src/generators/har.ts
+++ b/src/generators/har.ts
@@ -5,6 +5,7 @@ import type { Request, RequestUrl, Warnings } from "../parse.js";
 import { parseQueryString } from "../Query.js";
 import type { Request as HARRequest, PostData as PostData } from "har-format";
 
+const generatorName = "har";
 const supportedArgs = new Set([
   ...COMMON_SUPPORTED_ARGS,
 
@@ -31,7 +32,7 @@ function getDataString(request: Request): PostData | null {
   const mimeType = request.headers.getContentType() || "";
   try {
     // TODO: look at dataArray and generate fileName:
-    const [parsedQuery] = parseQueryString(request.data);
+    const [parsedQuery] = parseQueryString(request.data, generatorName);
     if (parsedQuery && parsedQuery.length) {
       return {
         mimeType,

--- a/src/generators/httpie.ts
+++ b/src/generators/httpie.ts
@@ -8,6 +8,7 @@ import { parseQueryString } from "../Query.js";
 
 import { repr, reprStr } from "./wget.js";
 
+const generatorName = "httpie";
 const supportedArgs = new Set([
   ...COMMON_SUPPORTED_ARGS,
   "form",
@@ -185,7 +186,7 @@ function escapeQueryValue(value: Word): Word {
 function urlencodedAsHttpie(flags: string[], items: string[], data: Word) {
   let queryList;
   try {
-    [queryList] = parseQueryString(data);
+    [queryList] = parseQueryString(data, generatorName);
   } catch {}
   if (!queryList) {
     flags.push("--raw " + (repr(data) || "''"));

--- a/src/generators/java/okhttp.ts
+++ b/src/generators/java/okhttp.ts
@@ -5,6 +5,7 @@ import { parseQueryString } from "../../Query.js";
 
 import { repr } from "./java.js";
 
+const generatorName = "okhttp";
 const supportedArgs = new Set([
   ...COMMON_SUPPORTED_ARGS,
   "max-time",
@@ -107,7 +108,7 @@ export function _toJavaOkHttp(
   } else if (request.data) {
     const contentType = request.headers.getContentType();
     if (contentType === "application/x-www-form-urlencoded") {
-      const [queryList] = parseQueryString(request.data);
+      const [queryList] = parseQueryString(request.data, generatorName);
       if (!queryList) {
         methodCallArgs.push("requestBody");
         javaCode +=

--- a/src/generators/javascript/axios.ts
+++ b/src/generators/javascript/axios.ts
@@ -16,6 +16,7 @@ import {
   reprImports,
 } from "./javascript.js";
 
+const generatorName = "axios";
 const supportedArgs = new Set([
   ...COMMON_SUPPORTED_ARGS,
   "max-time",
@@ -60,7 +61,10 @@ function _getDataString(
     return [jsonAsJavaScript, roundtrips ? null : originalStringRepr];
   }
   if (contentType === "application/x-www-form-urlencoded") {
-    const [queryList, queryDict] = parseQueryString(request.data);
+    const [queryList, queryDict] = parseQueryString(
+      request.data,
+      generatorName
+    );
     if (queryList) {
       // Technically axios sends
       // application/x-www-form-urlencoded;charset=utf-8

--- a/src/generators/javascript/got.ts
+++ b/src/generators/javascript/got.ts
@@ -15,7 +15,9 @@ import {
   addImport,
   bySecondElem,
 } from "./javascript.js";
+import { fileURLToPath, URL } from "url";
 
+const generatorName = "got";
 const supportedArgs = new Set([
   ...COMMON_SUPPORTED_ARGS,
 
@@ -80,7 +82,10 @@ function getBodyString(
       return [jsonAsJavaScript, roundtrips ? null : simpleString];
     }
     if (contentType === "application/x-www-form-urlencoded") {
-      const [queryList, queryDict] = parseQueryString(request.data);
+      const [queryList, queryDict] = parseQueryString(
+        request.data,
+        generatorName
+      );
       if (queryDict && queryDict.every((v) => !Array.isArray(v[1]))) {
         if (eq(exactContentType, "application/x-www-form-urlencoded")) {
           request.headers.delete("content-type");

--- a/src/generators/javascript/http.ts
+++ b/src/generators/javascript/http.ts
@@ -14,6 +14,7 @@ import {
 
 import { dedent, getFormString } from "./jquery.js";
 
+const generatorName = "http";
 const supportedArgs = new Set([
   ...COMMON_SUPPORTED_ARGS,
   "form",
@@ -41,7 +42,7 @@ function _getDataString(
     return [jsonAsJavaScript, roundtrips ? null : originalStringRepr];
   }
   if (contentType === "application/x-www-form-urlencoded") {
-    const query = parseQueryString(data);
+    const query = parseQueryString(data, generatorName);
     if (query[0]) {
       // if (
       //   eq(exactContentType, "application/x-www-form-urlencoded; charset=utf-8")

--- a/src/generators/javascript/javascript.ts
+++ b/src/generators/javascript/javascript.ts
@@ -8,6 +8,7 @@ import type { FormParam } from "../../curl/form.js";
 
 import jsescObj from "jsesc";
 
+const generatorName = "javascript";
 const javaScriptSupportedArgs = new Set([
   ...COMMON_SUPPORTED_ARGS,
   "upload-file",
@@ -438,7 +439,7 @@ function getDataString(
   }
   if (contentType === "application/x-www-form-urlencoded") {
     try {
-      const [queryList, queryDict] = parseQueryString(data);
+      const [queryList, queryDict] = parseQueryString(data, generatorName);
       if (queryList) {
         // Technically node-fetch sends
         // application/x-www-form-urlencoded;charset=utf-8

--- a/src/generators/javascript/jquery.ts
+++ b/src/generators/javascript/jquery.ts
@@ -14,6 +14,7 @@ import {
   reprImports,
 } from "./javascript.js";
 
+const generatorName = "jquery";
 const supportedArgs = new Set([
   ...COMMON_SUPPORTED_ARGS,
   "form",
@@ -105,7 +106,7 @@ function _getDataString(
     ];
   }
   if (contentType === "application/x-www-form-urlencoded") {
-    const [queryList, queryDict] = parseQueryString(data);
+    const [queryList, queryDict] = parseQueryString(data, generatorName);
     if (queryList) {
       if (
         eq(exactContentType, "application/x-www-form-urlencoded; charset=utf-8")

--- a/src/generators/javascript/ky.ts
+++ b/src/generators/javascript/ky.ts
@@ -18,7 +18,9 @@ import {
 } from "./javascript.js";
 
 import { getFormString } from "./jquery.js";
+import { fileURLToPath, URL } from "url";
 
+const generatorName = "ky";
 const supportedArgs = new Set([
   ...COMMON_SUPPORTED_ARGS,
   "upload-file",
@@ -58,7 +60,7 @@ function getDataString(
   }
   if (contentType === "application/x-www-form-urlencoded") {
     try {
-      const [queryList, queryDict] = parseQueryString(data);
+      const [queryList, queryDict] = parseQueryString(data, generatorName);
       if (queryList) {
         // Technically node-fetch sends
         // application/x-www-form-urlencoded;charset=utf-8

--- a/src/generators/javascript/superagent.ts
+++ b/src/generators/javascript/superagent.ts
@@ -17,6 +17,7 @@ import {
 
 import { indent } from "./jquery.js";
 
+const generatorName = "superagent";
 const supportedArgs = new Set([
   ...COMMON_SUPPORTED_ARGS,
   "form",
@@ -112,7 +113,10 @@ function _getDataString(
     ];
   }
   if (contentType === "application/x-www-form-urlencoded") {
-    const [queryList, queryDict] = parseQueryString(request.data);
+    const [queryList, queryDict] = parseQueryString(
+      request.data,
+      generatorName
+    );
     if (queryList) {
       exactContentType = null;
       const queryCode =

--- a/src/generators/javascript/xhr.ts
+++ b/src/generators/javascript/xhr.ts
@@ -14,6 +14,7 @@ import {
 
 import { dedent, getFormString } from "./jquery.js";
 
+const generatorName = "xhr";
 const supportedArgs = new Set([
   ...COMMON_SUPPORTED_ARGS,
   "form",
@@ -40,7 +41,7 @@ function _getDataString(
     return [jsonAsJavaScript, roundtrips ? null : originalStringRepr];
   }
   if (contentType === "application/x-www-form-urlencoded") {
-    const [queryList, queryDict] = parseQueryString(data);
+    const [queryList, queryDict] = parseQueryString(data, generatorName);
     if (queryList) {
       // TODO: check roundtrip, add a comment
       return [toURLSearchParams([queryList, queryDict], imports), null];

--- a/src/generators/json.ts
+++ b/src/generators/json.ts
@@ -1,5 +1,5 @@
-import { parse, getFirst, COMMON_SUPPORTED_ARGS } from "../parse.js";
 import type { Request, Warnings } from "../parse.js";
+import { COMMON_SUPPORTED_ARGS, getFirst, parse } from "../parse.js";
 import type { AuthType } from "../Request.js";
 import { parseQueryString } from "../Query.js";
 
@@ -70,6 +70,9 @@ function getDataString(request: Request): {
 } {
   if (!request.data) {
     return {};
+  }
+  if (request.data.toString() === "") {
+    return { data: request.data.toString() };
   }
 
   const contentType = request.headers.getContentType();
@@ -249,6 +252,7 @@ export function _toJsonString(
     ) + "\n"
   );
 }
+
 export function toJsonStringWarn(
   curlCommand: string | string[],
   warnings: Warnings = []
@@ -257,6 +261,7 @@ export function toJsonStringWarn(
   const json = _toJsonString(requests, warnings);
   return [json, warnings];
 }
+
 export function toJsonString(curlCommand: string | string[]): string {
   return toJsonStringWarn(curlCommand)[0];
 }

--- a/src/generators/kotlin.ts
+++ b/src/generators/kotlin.ts
@@ -3,6 +3,7 @@ import { parse, getFirst, COMMON_SUPPORTED_ARGS } from "../parse.js";
 import type { Request, Warnings } from "../parse.js";
 import { parseQueryString } from "../Query.js";
 
+const generatorName = "kotlin";
 const supportedArgs = new Set([
   ...COMMON_SUPPORTED_ARGS,
   "max-time",
@@ -187,7 +188,7 @@ export function _toKotlin(
     imports.add("java.io.File");
   } else if (request.data) {
     if (contentType === "application/x-www-form-urlencoded") {
-      const [queryList] = parseQueryString(request.data);
+      const [queryList] = parseQueryString(request.data, generatorName);
       if (!queryList) {
         if (exactContentType) {
           kotlinCode +=

--- a/src/generators/php/guzzle.ts
+++ b/src/generators/php/guzzle.ts
@@ -5,6 +5,7 @@ import { parseQueryString } from "../../Query.js";
 
 import { reprStr, repr } from "./php.js";
 
+const generatorName = "guzzle";
 const supportedArgs = new Set([
   ...COMMON_SUPPORTED_ARGS,
   "form",
@@ -234,7 +235,7 @@ export function _toPhpGuzzle(
     const contentType = request.headers.getContentType();
     if (contentType === "application/x-www-form-urlencoded") {
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const [_, queryAsDict] = parseQueryString(request.data);
+      const [_, queryAsDict] = parseQueryString(request.data, generatorName);
       if (queryAsDict) {
         options += "    'form_params' => [\n";
         for (const [name, value] of queryAsDict) {

--- a/src/generators/php/requests.ts
+++ b/src/generators/php/requests.ts
@@ -4,6 +4,7 @@ import { parseQueryString } from "../../Query.js";
 
 import { repr } from "./php.js";
 
+const generatorName = "requests";
 const supportedArgs = new Set([
   ...COMMON_SUPPORTED_ARGS,
   // "form",
@@ -48,7 +49,7 @@ export function _toPhpRequests(
 
   let dataString;
   if (request.data) {
-    const [parsedQueryString] = parseQueryString(request.data);
+    const [parsedQueryString] = parseQueryString(request.data, generatorName);
     dataString = "$data = array(\n";
     if (!parsedQueryString || !parsedQueryString.length) {
       dataString = "$data = " + repr(request.data) + ";";

--- a/src/generators/powershell.ts
+++ b/src/generators/powershell.ts
@@ -4,6 +4,7 @@ import { Word, eq } from "../shell/Word.js";
 import type { Request, RequestUrl, Warnings } from "../parse.js";
 import { parseQueryString } from "../Query.js";
 
+const generatorName = "powershell";
 // https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_quoting_rules
 // https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_special_characters
 // https://learn.microsoft.com/en-us/powershell/scripting/learn/deep-dives/everything-about-string-substitutions
@@ -238,7 +239,7 @@ function requestToPowershell(
     if (contentType === "application/x-www-form-urlencoded") {
       let queryList, queryDict;
       try {
-        [queryList, queryDict] = parseQueryString(request.data);
+        [queryList, queryDict] = parseQueryString(request.data, generatorName);
       } catch {}
       if (
         queryList &&

--- a/src/generators/r.ts
+++ b/src/generators/r.ts
@@ -6,6 +6,7 @@ import type { QueryList } from "../Query.js";
 
 import { reprStr as pyrepr } from "./python.js";
 
+const generatorName = "r";
 const supportedArgs = new Set([
   ...COMMON_SUPPORTED_ARGS,
   "form",
@@ -175,7 +176,7 @@ export function _toR(requests: Request[], warnings: Warnings = []): string {
       const filePath = request.data.slice(1);
       dataString = "data = upload_file(" + repr(filePath) + ")";
     } else {
-      const [parsedQueryString] = parseQueryString(request.data);
+      const [parsedQueryString] = parseQueryString(request.data, generatorName);
       // repeat to satisfy type checker
       dataIsList = parsedQueryString && parsedQueryString.length;
       if (dataIsList) {

--- a/src/generators/ruby.ts
+++ b/src/generators/ruby.ts
@@ -5,6 +5,7 @@ import { parse, COMMON_SUPPORTED_ARGS } from "../parse.js";
 import type { Request, Warnings } from "../parse.js";
 import { parseQueryString, type QueryDict } from "../Query.js";
 
+const generatorName = "ruby";
 // https://ruby-doc.org/stdlib-2.7.0/libdoc/net/http/rdoc/Net/HTTP.html
 // https://github.com/ruby/net-http/tree/master/lib/net
 // https://github.com/augustl/net-http-cheat-sheet
@@ -255,7 +256,7 @@ function getDataString(request: Request): [string, boolean] {
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const [_, queryAsDict] = parseQueryString(request.data);
+  const [_, queryAsDict] = parseQueryString(request.data, generatorName);
   if (!request.isDataBinary && queryAsDict) {
     // If the original request contained %20, Ruby will encode them as "+"
     return ["req.set_form_data(" + queryToRubyDict(queryAsDict) + ")\n", false];

--- a/test/fixtures/json/j_patch_array.json
+++ b/test/fixtures/json/j_patch_array.json
@@ -6,6 +6,10 @@
         "Content-Type": "application/x-www-form-urlencoded"
     },
     "data": {
-        "item[]=1&item[]=2&item[]=3": ""
+        "item[]": [
+            "1",
+            "2",
+            "3"
+        ]
     }
 }

--- a/test/fixtures/json/multiple_d_post.json
+++ b/test/fixtures/json/multiple_d_post.json
@@ -6,6 +6,9 @@
         "Content-Type": "application/x-www-form-urlencoded"
     },
     "data": {
-        "version=1.2&auth_user=fdgxf&auth_pwd=oxfdscds&json_data={ \"operation\": \"core/get\", \"class\": \"Software\", \"key\": \"key\" }": ""
+        "version": "1.2",
+        "auth_user": "fdgxf",
+        "auth_pwd": "oxfdscds",
+        "json_data": "{ \"operation\": \"core/get\", \"class\": \"Software\", \"key\": \"key\" }"
     }
 }

--- a/test/fixtures/json/post_with_data_raw.json
+++ b/test/fixtures/json/post_with_data_raw.json
@@ -6,6 +6,8 @@
         "Content-Type": "application/x-www-form-urlencoded"
     },
     "data": {
-        "msg1=wow&msg2=such&msg3=@rawmsg": ""
+        "msg1": "wow",
+        "msg2": "such",
+        "msg3": "@rawmsg"
     }
 }


### PR DESCRIPTION
- Changed parseQueryString function from Query.js to allow specific runtime/library percent encodes.
- Added specific json percent encode