### PR TITLE
Set data to a string in JSON output

### DIFF
--- a/src/curl/opts.ts
+++ b/src/curl/opts.ts
@@ -901,7 +901,7 @@ export interface OperationConfig {
   // TODO: remove any.
   // This is difficult because we have curl's arguments but also a couple
   // curlconverter-specific arguments that are handled by the same code.
-  [key: string]: any; // eslint-disable-line @typescript-eslint/no-explicit-any
+  [key: string]: any;
 }
 // type Satisfies<T, U extends T> = void;
 // type AssertSubsetKeys = Satisfies<

--- a/src/generators/julia.ts
+++ b/src/generators/julia.ts
@@ -174,7 +174,7 @@ function formatData(request: Request, imports: Set<string>): [string, string] {
       try {
         const jsonData = jsonParseLossless(
           request.dataArray[0].toString()
-        ) as any; // eslint-disable-line @typescript-eslint/no-explicit-any
+        ) as any;
         const result = jsonAsJulia(jsonData);
         imports.add("JSON");
         return [result, "JSON.json(body)"];

--- a/src/generators/lua.ts
+++ b/src/generators/lua.ts
@@ -6,11 +6,6 @@ import { reprStr as pyreprStr } from "./python/python.js";
 
 const supportedArgs = new Set([
   ...COMMON_SUPPORTED_ARGS,
-  // "insecure",
-  // "no-insecure",
-  // "compressed",
-  // "no-compressed",
-  // "max-time",
   // "form",
   // "form-string",
 ]);

--- a/test/fixtures/json/j_patch_array.json
+++ b/test/fixtures/json/j_patch_array.json
@@ -5,7 +5,5 @@
     "headers": {
         "Content-Type": "application/x-www-form-urlencoded"
     },
-    "data": {
-        "item[]=1&item[]=2&item[]=3": ""
-    }
+    "data": "item[]=1&item[]=2&item[]=3"
 }

--- a/test/fixtures/json/multiple_d_post.json
+++ b/test/fixtures/json/multiple_d_post.json
@@ -5,7 +5,5 @@
     "headers": {
         "Content-Type": "application/x-www-form-urlencoded"
     },
-    "data": {
-        "version=1.2&auth_user=fdgxf&auth_pwd=oxfdscds&json_data={ \"operation\": \"core/get\", \"class\": \"Software\", \"key\": \"key\" }": ""
-    }
+    "data": "version=1.2&auth_user=fdgxf&auth_pwd=oxfdscds&json_data={ \"operation\": \"core/get\", \"class\": \"Software\", \"key\": \"key\" }"
 }

--- a/test/fixtures/json/post_with_data_binary.json
+++ b/test/fixtures/json/post_with_data_binary.json
@@ -5,7 +5,5 @@
     "headers": {
         "Content-Type": "application/x-www-form-urlencoded"
     },
-    "data": {
-        "{\"title\":\"china1\"}": ""
-    }
+    "data": "{\"title\":\"china1\"}"
 }

--- a/test/fixtures/json/post_with_data_raw.json
+++ b/test/fixtures/json/post_with_data_raw.json
@@ -5,7 +5,5 @@
     "headers": {
         "Content-Type": "application/x-www-form-urlencoded"
     },
-    "data": {
-        "msg1=wow&msg2=such&msg3=@rawmsg": ""
-    }
+    "data": "msg1=wow&msg2=such&msg3=@rawmsg"
 }

--- a/test/fixtures/json/post_xpost.json
+++ b/test/fixtures/json/post_xpost.json
@@ -5,7 +5,5 @@
     "headers": {
         "Content-Type": "application/x-www-form-urlencoded"
     },
-    "data": {
-        "{\"keywords\":\"php\",\"page\":1,\"searchMode\":1}": ""
-    }
+    "data": "{\"keywords\":\"php\",\"page\":1,\"searchMode\":1}"
 }


### PR DESCRIPTION
Also, only parse data as a query string when the command has the correct Content-Type header set.

Fixes #618 (also see #457)