### PR TITLE
Load tree-sitter-bash.wasm from the same directory as the JavaScript

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ curlconverter.toPythonWarn(['curl', 'ftp://example.com']);
 // ]
 ```
 
-If you want to host curlconverter yourself and use it in the browser, it needs two [WASM](https://developer.mozilla.org/en-US/docs/WebAssembly) files to work, `tree-sitter.wasm` and `tree-sitter-bash.wasm`, which it will request from the root directory of your web server. If you are hosting a static website and using Webpack, you need to copy these files from the node_modules/ directory to your server's root directory in order to serve them. You can look at the [webpack.config.js](https://github.com/curlconverter/curlconverter.github.io/blob/2e1722891be22b1bb5c47976fb7873f6eb86b94d/webpack.config.js#L130-L131) for [curlconverter.com](https://curlconverter.com/) to see how this is done. You will also need to set `{module: {experiments: {topLevelAwait: true}}}` in your webpack.config.js.
+If you want to host curlconverter yourself and use it in the browser, it needs two [WASM](https://developer.mozilla.org/en-US/docs/WebAssembly) files to work, `tree-sitter.wasm` and `tree-sitter-bash.wasm`, which it will request from the same directory as the JavaScript file that imports them. If you are hosting a static website and using Webpack, you need to copy these files from the node_modules/ directory to the appropriate directory in order to serve them. You can look at the [webpack.config.js](https://github.com/curlconverter/curlconverter.github.io/blob/2e1722891be22b1bb5c47976fb7873f6eb86b94d/webpack.config.js#L130-L131) for [curlconverter.com](https://curlconverter.com/) to see how this is done (the JavaScript and Wasm files are served from the root directory). You will also need to set `{module: {experiments: {topLevelAwait: true}}}` in your webpack.config.js.
 
 ### Usage in VS Code
 

--- a/src/shell/webParser.ts
+++ b/src/shell/webParser.ts
@@ -5,7 +5,7 @@ import Parser from "web-tree-sitter";
 // NOTE: top-level await requires Safari 15+
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/await#browser_compatibility
 await Parser.init();
-const Bash = await Parser.Language.load("/tree-sitter-bash.wasm");
+const Bash = await Parser.Language.load("./tree-sitter-bash.wasm");
 const parser = new Parser();
 parser.setLanguage(Bash);
 


### PR DESCRIPTION
instead of from the root directory. Works on #617