### PR TITLE
Fix missing comma in node-ky conversion

### DIFF
--- a/src/generators/javascript/ky.ts
+++ b/src/generators/javascript/ky.ts
@@ -202,7 +202,8 @@ function requestToKy(
     if (urlObj.queryList) {
       optionsCode +=
         "searchParams: " +
-        toDictOrURLSearchParams([urlObj.queryList, urlObj.queryDict], imports);
+        toDictOrURLSearchParams([urlObj.queryList, urlObj.queryDict], imports) +
+        ",\n";
     }
     if (urlObj.queryReadsFile) {
       warnings.push([


### PR DESCRIPTION
This PR addresses an issue where a comma was missing in the generated nodejs-ky code when the curl command included searchParams. 

Wrong example
```bash
curl -X GET 'https://example.com/?foo=bar' -H 'Accept: application/json'
```

Wrong result
```javascript
import ky from 'ky';

ky.get('https://example.com/', {
searchParams: {
    'foo': 'bar'
  }  headers: {
    'Accept': 'application/json'
  }
});
```
